### PR TITLE
refactor: maintain explicit command structure for config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,228 +1,80 @@
-# 🚀 (@itwibrc/devkit) Dev Kit (`dk`)
-
-A universal CLI for professional developers to automate project scaffolding and streamline workflows.
-
-**Dev Kit** (`dk`) is a powerful command-line tool designed to boost your productivity by automating repetitive tasks. Whether you're setting up a new machine or starting a new project, `dk` is your essential solution for project automation.
-
-Built to fit the modern developer workflow, `dk` seamlessly integrates into monorepos and supports a wide range of features to help you start coding faster.
-
 ---
 
-## ✨ Key Features
+### `CONTRIBUTING.md`
 
-- **Unified Command:** Access all features with the short, intuitive command `dk`.
-- **Intelligent Scaffolding:** Create new projects from popular frameworks with a single, intuitive command. You can also use custom templates for a consistent workflow.
-- **Robust Configuration:** The tool reliably finds your configuration file (`.devkitrc`) in any project or monorepo structure.
-- **Powerful Cache Management:** Optimize project setup speed with flexible caching strategies for your templates. These strategies are mainly applied when using a GitHub URL:
-  - `always-refresh`: Always pull the latest template from the remote repository.
-  - `never-refresh`: Use the local cached template without checking for updates.
-  - `daily` (default): Refresh the cache only once every 24 hours.
-- **Seamless Internationalization (i18n):** The CLI supports multiple languages, with all commands and descriptions dynamically translated. It will automatically use the language defined in your configuration files or **detect your system's language as a fallback** for a seamless out-of-the-box experience.
-- **Centralized Settings:** Manage your preferred package manager (npm, yarn, pnpm, bun, deno) and cache strategy with a single command.
+Create a file named **`CONTRIBUTING.md`** in your repository's root directory.
 
----
+````markdown
+# 🤝 Contributing to DevKit
 
-## 📂 Use Cases
+First off, thank you for considering contributing to DevKit! It's people like you that make open source such a great community. We appreciate your time and effort.
 
-The Dev Kit CLI streamlines development workflows in various environments:
+The following is a set of guidelines for contributing to DevKit. These are mostly guidelines, not strict rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
 
-- **Globally Installed CLI:** Install `dk` globally for a universal scaffolding tool on your machine.
-- **Monorepo:** A single configuration file at the root can manage settings and templates for all projects, ensuring consistency across your entire codebase.
-- **Multiple Repositories:** Each project can have its own `.devkitrc` file for unique settings, allowing for flexible project management.
+## ⚖️ Code of Conduct
 
----
+This project and everyone participating in it is governed by the [Code of Conduct](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html). By participating, you are expected to uphold this code.
 
-## 🗺️ Supported Languages
+## 🐛 How to Report a Bug
 
-The CLI's internationalization (`i18n`) feature dynamically translates commands and descriptions. Currently, the following languages are supported:
+Before submitting a bug report, please check if the issue has already been reported. If you find a similar issue, you can add a comment to it instead of opening a new one.
 
-- English (`en`)
-- French (`fr`)
+When creating a new bug report, please use our **[Bug Report Template](.github/ISSUE_TEMPLATE/bug_report.md)** to provide the necessary information. This helps us understand and fix the problem more quickly.
 
----
+## ✨ How to Suggest an Enhancement
 
-## 🚀 Getting Started
+We're always looking for ways to improve DevKit! Use our **[Feature Request Template](.github/ISSUE_TEMPLATE/feature_request.md)** to suggest a new feature or enhancement. A good feature request includes a clear description of the problem you're facing and the solution you have in mind.
 
-### Prerequisites
+## 💻 Your First Contribution
 
-Ensure you have **Node.js (v18 or higher)** and a package manager installed.
+If you're looking for an issue to get started with, check out the issues with the "good first issue" label.
 
-### Installation
+### Development Setup
 
-Install Dev Kit globally using your preferred package manager.
+To contribute code, you'll need to set up your local development environment.
 
-```bash
-# using bun
-bun install -g devkit
+1.  **Fork the repository** on GitHub.
+2.  **Clone your forked repository** to your local machine.
+    ```bash
+    git clone [https://github.com/your-username/devkit.git](https://github.com/your-username/devkit.git)
+    cd devkit
+    ```
+3.  **Install dependencies**. DevKit uses a package manager.
+    ```bash
+    npm install # or yarn install, pnpm install, bun install
+    ```
+4.  **Build the project** to compile the TypeScript code.
+    ```bash
+    npm run build
+    ```
+5.  **Run the CLI locally** using `npm link` or `bun link`. This will make the `dk` command available globally on your machine and point it to your local source code.
+    ```bash
+    npm link
+    ```
+    Now you can run `dk --help` to test your local changes.
 
-# using npm
-npm install -g devkit
+### Submitting a Pull Request
 
-# using pnpm
-pnpm install -g devkit
+When you're ready to submit your changes, please use our **[Pull Request Template](.github/PULL_REQUEST_TEMPLATE.md)** to ensure all required information is provided.
 
-# using yarn
-yarn global add devkit
-```
+**Commit Message Convention**
+We use Conventional Commits for our commit messages. This allows for automated changelog generation and versioning.
 
-### Verify Installation
+- `feat`: A new feature
+- `fix`: A bug fix
+- `docs`: Documentation only changes
+- `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
+- `refactor`: A code change that neither fixes a bug nor adds a feature
+- `test`: Adding missing tests or correcting existing tests
+- `chore`: Changes to the build process or auxiliary tools and libraries such as documentation generation
 
-To confirm everything is working, run the help command.
+**Example:**
+`feat: add support for pnpm package manager`
 
-```bash
-dk --help
-```
+**Before Submitting**
 
----
+- Make sure your changes are formatted and linted correctly.
+- Run the tests (`npm test`) to ensure everything works as expected.
 
-## ⚙️ Usage
-
-Here's how to get started with the Dev Kit CLI.
-
-### Create a new project from a template
-
-```bash
-# Create a new Vue project from a custom template
-dk new vue my-awesome-app
-```
-
-### Manage your CLI configuration
-
-Use the `config set` command to update your `.devkitrc` file.
-
-```bash
-# Set your default package manager to pnpm
-dk config set pm pnpm
-
-# Set the language to French
-dk config set language fr
-```
-
-### Manage cache strategy for a template
-
-Use the `config cache` command to update the cache strategy for a specific template.
-
-```bash
-# Set the cache strategy for the 'react' template to 'always-refresh'
-dk config cache react always-refresh
-```
-
-### Shortcuts
-
-For a faster workflow, the following commands have shortcuts:
-
-- `devkit` -\> `dk`
-- `init` -\> `i`
-- `config` -\> `cf`
-- `cache` -\> `c`
-
----
-
-## ⚙️ Configuration
-
-Manage your configuration either through the CLI or by manual editing.
-
-### Configuration Hierarchy
-
-Dev Kit now loads settings with a clear priority to give you maximum control and flexibility.
-
-1.  **Local Project Configuration (`./.devkitrc`)**: This file, at the root of your project, takes the **highest priority**.
-2.  **Global Configuration (`~/.devkitrc`)**: This file, stored in your user's home directory, is used for all projects on your machine and is overridden by a local configuration.
-3.  **System Language Detection**: If a language setting is not found in either the local or global configuration, `dk` will **automatically detect your system's language** and load the corresponding translations.
-4.  **Default**: If none of the above are found, the language will default to English (`en`).
-
-### Create and configure a project file
-
-To initialize a local configuration file in your project, use `config init`. This creates a `.devkitrc` file in the current directory.
-
-```bash
-dk config init
-```
-
-### Add the JSON Schema for Autocompletion
-
-For a better developer experience, add a `$schema` property for auto-completion and validation in editors like VS Code.
-
-```json
-{
-  "$schema": "https://raw.githubusercontent.com/IT-WIBRC/devkit/main/schema.json",
-  "settings": {
-    "language": "fr",
-    "defaultPackageManager": "npm",
-    "cacheStrategy": "daily"
-  },
-  "templates": {
-    "react": {
-      "templates": {
-        "ts": {
-          "location": "https://github.com/IT-WIBRC/react-ts-template"
-        }
-      }
-    }
-  }
-}
-```
-
-### Template Configuration
-
-Dev Kit provides a set of default templates and we'll progressively add more. The `location` property for a custom template can be a local folder, a GitHub URL, or a command. Note that cache strategies are only applied when using a GitHub URL.
-
-You can also define an **`alias`** to make it easier to reference a specific template. An alias is a simple shortcut for a template's name.
-
-```json
-{
-  "templates": {
-    "my-app": {
-      "templates": {
-        "my-local-template": {
-          "description": "A template from my local machine",
-          "location": "/Users/myuser/projects/my-local-template"
-        },
-        "from-github": {
-          "description": "A template from a GitHub repository",
-          "location": "https://github.com/my-user/my-template-repo",
-          "alias": "gh-template"
-        },
-        "from-create-command": {
-          "description": "Uses the native `create` command",
-          "location": "{pm} create nuxt@latest"
-        }
-      }
-    }
-  }
-}
-```
-
-### Using a custom template with an alias
-
-Once an alias is configured, you can use it in place of the full template name for faster commands.
-
-```bash
-# Create a new project using the alias 'gh-template'
-dk new my-app gh-template my-new-project-name
-```
-
----
-
-## 🗺️ Roadmap & Future Features
-
-This project is in its early stages. We're committed to building a comprehensive developer toolkit.
-
-- **Multi-Programming Language Support:** We'll progressively add templates for various frameworks and ecosystems (e.g., Python, Ruby, Go, Rust).
-- **Advanced Documentation:** Detailed guides on creating and managing custom templates, with examples for various frameworks.
-
----
-
-## 🤝 Contributing
-
-We welcome contributions\! Please see our [Contributing Guide](./CONTRIBUTING.md) for details on how to get started.
-
----
-
-## 📄 License
-
-MIT
-
-Copyright (c) 2025, WAFFEU Ivany Botrel Rayn
-Contact
-Ivany Botrel Rayn WAFFEU - wibrc.se.jc@gmail.com
+Thank you for your contribution!
+````

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Built to fit the modern developer workflow, `dk` seamlessly integrates into mono
   - `always-refresh`: Always pull the latest template from the remote repository.
   - `never-refresh`: Use the local cached template without checking for updates.
   - `daily` (default): Refresh the cache only once every 24 hours.
-- **Seamless Internationalization (i18n):** The CLI supports multiple languages, with all commands and descriptions dynamically translated. It **automatically detects your system's language** as a fallback, ensuring a seamless out-of-the-box experience.
+- **Seamless Internationalization (i18n):** The CLI supports multiple languages, with all commands and descriptions dynamically translated. It will automatically use the language defined in your configuration files or **detect your system's language as a fallback** for a seamless out-of-the-box experience.
 - **Centralized Settings:** Manage your preferred package manager (npm, yarn, pnpm, bun, deno) and cache strategy with a single command.
 
 ---
@@ -127,7 +127,7 @@ Manage your configuration either through the CLI or by manual editing.
 Dev Kit now loads settings with a clear priority to give you maximum control and flexibility.
 
 1.  **Local Project Configuration (`./.devkitrc`)**: This file, at the root of your project, takes the **highest priority**.
-2.  **Global Configuration (`~/.devkitrc`)**: This file, stored in your user's home directory, is used for all projects on your machine and is overridden by any local configuration.
+2.  **Global Configuration (`~/.devkitrc`)**: This file, stored in your user's home directory, is used for all projects on your machine and is overridden by a local configuration.
 3.  **System Language Detection**: If a language setting is not found in either the local or global configuration, `dk` will **automatically detect your system's language** and load the corresponding translations.
 4.  **Default**: If none of the above are found, the language will default to English (`en`).
 
@@ -215,13 +215,7 @@ This project is in its early stages. We're committed to building a comprehensive
 
 ## 🤝 Contributing
 
-We welcome contributions\! If you have a feature idea, find a bug, or want to contribute code, please open an issue or a pull request.
-
-1.  Fork the repository.
-2.  Create your feature branch (`git checkout -b feature/amazing-feature`).
-3.  Commit your changes (`git commit -m 'feat: Add amazing feature'`).
-4.  Push to the branch (`git push origin feature/amazing-feature`).
-5.  Open a pull request.
+We welcome contributions\! Please see our [Contributing Guide](./CONTRIBUTING.md) for details on how to get started.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@ This document tracks all planned tasks, bugs, and future ideas for the Dev Kit p
 - [ ] Use changesets for changelog and versioning, and automate the process
 - [ ] (Maybe) Support environment variables
 - [ ] Add argument support like `--template` or `-t`
-- [ ] Check what can be changed into an argument instead of a command
+- [x] Check what can be changed into an argument instead of a command
 - [ ] Support template creation using a command
 - [x] Detect system language dynamically
 - [x] Support Monorepo configuration


### PR DESCRIPTION
## Description

This PR maintains the current command structure for the `config` command (`dk config set`, `dk config cache`) rather than refactoring to an option-based system (e.g., `dk config --set`).

The decision to retain the current design is based on the following reasons:

* **Clarity and Explicitness:** Using subcommands like `set` and `cache` makes the user's intent immediately clear. `dk config set` reads as a direct instruction to "set a configuration," while `dk config cache` explicitly states the action of "managing the cache."
* **Alignment with CLI Conventions:** This command structure is a widely adopted standard among powerful CLI tools like `git` and `npm`. Following this convention makes the DevKit CLI familiar and easy to learn.
* **Future Scalability:** Keeping each distinct action as a separate subcommand simplifies the addition of new features in the future (e.g., `config view`) without cluttering a single command with numerous flags.

Fixes # (Not applicable, this is a design decision commit)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
