### PR TITLE
feat: support template creation using a command

### DIFF
--- a/.devkitrc.json
+++ b/.devkitrc.json
@@ -1,11 +1,24 @@
 {
-  "$schema": "https://shorturl.at/QDcxK",
   "templates": {
-    "nodejs": {
+    "javascript": {
       "templates": {
         "simple": {
           "description": "A basic Node.js starter project.",
           "location": "./templates/nodejs/simple"
+        },
+        "vue": {
+          "description": "An official Vue.js project.",
+          "location": "{pm} create vue@latest",
+          "cacheStrategy": "always-refresh"
+        },
+        "nuxt": {
+          "description": "An official Nuxt.js project.",
+          "location": "{pm} create nuxt@latest",
+          "alias": "nx"
+        },
+        "nest": {
+          "description": "An official Nest.js project.",
+          "location": "{pm} install -g @nestjs/cli && nest new"
         },
         "medium": {
           "description": "A more complex project with a pre-configured database.",
@@ -14,11 +27,6 @@
         "vitrine": {
           "description": "A lightweight project for showcase websites.",
           "location": "./templates/nodejs/vitrine"
-        },
-        "vue": {
-          "description": "An official Vue.js project.",
-          "location": "{pm} create vue@latest",
-          "cacheStrategy": "always-refresh"
         },
         "my-custom-template": {
           "description": "A template for my team's projects.",
@@ -29,6 +37,8 @@
   },
   "settings": {
     "defaultPackageManager": "bun",
+    "cacheStrategy": "daily",
     "language": "en"
-  }
+  },
+  "$schema": "https://shorturl.at/QDcxK"
 }

--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ Here's how to get started with the Dev Kit CLI.
 dk new vue my-awesome-app
 ```
 
+### Add a new template to your configuration
+
+The `add-template` command allows you to easily register a new template with your CLI. It intelligently updates the configuration file in your current context:
+
+- **Global:** If no project is found, it updates your global (`~/.devkitrc`) file.
+- **Local:** It updates the `.devkitrc` file in the root of your current project.
+- **Monorepo:** It updates the shared configuration at the monorepo's root.
+
+You must provide a `description` using the `--description` flag. Other options like `--alias` and `--cache-strategy` are available to customize the template.
+
+```bash
+# Example: Add a new template from a GitHub repository
+dk add-template react react-ts-template https://github.com/my-user/my-react-ts-template --description "My custom React TS template"
+```
+
 ### Manage your CLI configuration
 
 Use the `config set` command to update your `.devkitrc` file.
@@ -115,6 +130,7 @@ For a faster workflow, the following commands have shortcuts:
 - `init` -\> `i`
 - `config` -\> `cf`
 - `cache` -\> `c`
+- `add-template` -\> `at`
 
 ---
 
@@ -131,12 +147,47 @@ Dev Kit now loads settings with a clear priority to give you maximum control and
 3.  **System Language Detection**: If a language setting is not found in either the local or global configuration, `dk` will **automatically detect your system's language** and load the corresponding translations.
 4.  **Default**: If none of the above are found, the language will default to English (`en`).
 
-### Create and configure a project file
+### Creating a New Template (The Full Workflow)
 
-To initialize a local configuration file in your project, use `config init`. This creates a `.devkitrc` file in the current directory.
+Dev Kit allows you to create and use your own templates in three simple steps.
+
+#### Step 1: Create the Template Project
+
+First, build your template. This is a standard project directory containing all the files you want to use. You can use any type of project, from a simple boilerplate to a complex custom setup.
+
+#### Step 2: Add the Template to Your Config
+
+Once your template project is ready, use the `add-template` command to register it with the CLI. This command adds the template's details to your `.devkitrc` file, making it available for use.
 
 ```bash
+# Add a template from a local folder to your global config
+dk add-template javascript custom-js-app /Users/myuser/projects/my-template --description "My personal JavaScript boilerplate" --global
+```
+
+#### Step 3: Use the Template
+
+After running the `add-template` command, you can scaffold a new project from your template using `dk new`.
+
+```bash
+# Create a new project from the template we just added
+dk new javascript custom-js-app my-new-project
+```
+
+### Create and configure a project file
+
+The `config init` command now allows you to initialize a configuration file at different scopes.
+
+- To initialize a **local** configuration file in your current project, simply run the command without any flags.
+- To initialize a **global** configuration file, use the `--global` flag.
+
+<!-- end list -->
+
+```bash
+# Initialize a local configuration file in the current directory
 dk config init
+
+# Initialize a global configuration file
+dk config init --global
 ```
 
 ### Add the JSON Schema for Autocompletion
@@ -145,7 +196,7 @@ For a better developer experience, add a `$schema` property for auto-completion 
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/IT-WIBRC/devkit/main/schema.json",
+  "$schema": "https://www.shorturl.at/QDcxK",
   "settings": {
     "language": "fr",
     "defaultPackageManager": "npm",

--- a/TODO.md
+++ b/TODO.md
@@ -13,11 +13,22 @@ This document tracks all planned tasks, bugs, and future ideas for the Dev Kit p
 - [ ] Use changesets for changelog and versioning, and automate the process
 - [ ] (Maybe) Support environment variables
 - [x] Check what can be changed into an argument instead of a command
-- [ ] Support template creation using a command
+- [x] Support template creation using a command
+- [ ] Update `$schema` to use to allow autocompletion in editors
 - [x] Detect system language dynamically
 - [x] Support Monorepo configuration
 - [x] Configure aliases
 - [ ] Find a way to test the templates
+- [ ] Refactor the `new` command to accept option to select a template
+- [ ] Warn user to not use already used names for templates and tell we only support js templates containing nodejs related templates
+- [ ] Add a command to list all available templates
+- [ ] Add a command to remove a template
+- [ ] Add a command to update a template
+- [ ] Add a command to update the CLI itself
+- [ ] Add a command to update the templates
+- [ ] Add a command to update the configuration
+- [ ] Add a command to update the language configuration
+- [ ] Add integration tests in addition to unit tests (reproduce monorepo, multi repo and bare repository)
 - [x] Enable copilot reviews for the project on GitHub (Impossible as it's not free as expected)
 
 ## Internationalization & Documentation

--- a/packages/devkit/locales/en.json
+++ b/packages/devkit/locales/en.json
@@ -62,7 +62,9 @@
       },
       "option": {
         "global": "Update the global configuration instead of the local one."
-      }
+      },
+      "updating": "Updating configuration...",
+      "success": "Configuration updated successfully."
     },
     "init": {
       "command": {
@@ -70,7 +72,11 @@
       },
       "start": "Initializing global config at {path}...",
       "success": "Global configuration file created successfully!",
-      "fail": "Failed to initialize global config."
+      "fail": "Failed to initialize global config.",
+      "initializing": "Initializing configuration...",
+      "option": {
+        "local": "Initialize a local configuration file instead of a global one."
+      }
     },
     "update": {
       "start": "Updating setting: {key}...",
@@ -92,7 +98,8 @@
       },
       "start": "Updating cache strategy for template '{template}'...",
       "success": "Cache strategy for template '{template}' updated to '{strategy}'",
-      "fail": "Failed to update cache strategy for template '{template}'"
+      "fail": "Failed to update cache strategy for template '{template}'",
+      "updating": "Updating cache..."
     },
     "check": {
       "local": "Checking for local or monorepo configuration...",
@@ -125,7 +132,8 @@
       "init": {
         "fail": "Failed to initialize configuration."
       },
-      "read": "Failed to read configuration at {path}."
+      "read": "Failed to read configuration at {path}.",
+      "no_file_found": "No configuration file found. Run 'devkit config init' to create a global one, or 'devkit config init --local' to create a local one."
     },
     "file": {
       "not_found": "Could not find file '{fileName}'."
@@ -170,7 +178,8 @@
       "generic": "Git error"
     },
     "unexpected": "An unexpected error occurred",
-    "unknown": "An unknown error occurred"
+    "unknown": "An unknown error occurred",
+    "language_config_not_found": "Scaffolding language not found in configuration: '{language}'"
   },
   "cache": {
     "clone": {
@@ -204,6 +213,20 @@
           "initialized": "Global configuration not initialized. Run 'devkit config init' to create one."
         }
       }
+    },
+    "no_config_found": "⚠️ No configuration file found. Using default settings."
+  },
+  "cli": {
+    "add_template": {
+      "description": "Add a new template to the configuration",
+      "options": {
+        "description": "A brief description of the template",
+        "alias": "A short alias for the template",
+        "cache": "The cache strategy for the template",
+        "package_manager": "The package manager to use for the template"
+      },
+      "adding": "Adding template '{templateName}' to configuration...",
+      "success": "Template '{templateName}' added successfully!"
     }
   }
 }

--- a/packages/devkit/locales/fr.json
+++ b/packages/devkit/locales/fr.json
@@ -1,7 +1,7 @@
 {
   "program": {
-    "description": "Une puissante boîte à outils pour échafauder de nouveaux projets.",
-    "initialized": "CLI initialisée avec succès."
+    "description": "Une boîte à outils puissante pour l'échafaudage de nouveaux projets.",
+    "initialized": "Interface de ligne de commande (CLI) initialisée avec succès."
   },
   "new": {
     "command": {
@@ -15,16 +15,16 @@
     }
   },
   "version": {
-    "description": "Afficher la version actuelle de la CLI."
+    "description": "Afficher la version actuelle de l'interface de ligne de commande (CLI)."
   },
   "help": {
     "description": "Afficher l'aide pour une commande."
   },
   "scaffolding": {
     "project": {
-      "start": "Échafaudage du projet {language} : {project}",
+      "start": "Échafaudage du projet {language}: {project}",
       "success": "✅ Projet {language} '{project}' créé avec succès !",
-      "fail": "❌ Échec de l'échafaudage du projet {language} : {error}"
+      "fail": "❌ Échec de l'échafaudage du projet {language}: {error}"
     },
     "copy": {
       "start": "📂 Copie des fichiers du modèle local...",
@@ -32,9 +32,9 @@
       "fail": "❌ Échec de la copie du modèle local."
     },
     "run": {
-      "start": "📦 Exécution de la commande CLI officielle : {command}...",
-      "success": "✅ Commande CLI officielle exécutée avec succès !",
-      "fail": "❌ Échec de l'exécution de la commande CLI officielle."
+      "start": "📦 Exécution de la commande officielle CLI: {command}...",
+      "success": "✅ Commande officielle CLI exécutée avec succès !",
+      "fail": "❌ Échec de l'exécution de la commande officielle CLI."
     },
     "install": {
       "start": "📦 Installation des dépendances avec {pm}...",
@@ -62,7 +62,9 @@
       },
       "option": {
         "global": "Mettre à jour la configuration globale au lieu de la locale."
-      }
+      },
+      "updating": "Mise à jour de la configuration...",
+      "success": "Configuration mise à jour avec succès."
     },
     "init": {
       "command": {
@@ -70,11 +72,15 @@
       },
       "start": "Initialisation de la configuration globale à {path}...",
       "success": "Fichier de configuration global créé avec succès !",
-      "fail": "Échec de l'initialisation de la configuration globale."
+      "fail": "Échec de l'initialisation de la configuration globale.",
+      "initializing": "Initialisation de la configuration...",
+      "option": {
+        "local": "Initialiser un fichier de configuration local au lieu d'un global."
+      }
     },
     "update": {
       "start": "Mise à jour du paramètre : {key}...",
-      "success": "✅ '{key}' mis à jour avec succès à '{value}' !",
+      "success": "✅ Paramètre {key} mis à jour avec succès à {value} !",
       "fail": "❌ Échec de la mise à jour du paramètre."
     },
     "cache": {
@@ -82,7 +88,7 @@
         "description": "Mettre à jour la stratégie de cache pour un modèle spécifique.",
         "start": "Mise à jour de la stratégie de cache pour le modèle '{template}'...",
         "fail": "❌ Échec de la mise à jour de la stratégie de cache pour le modèle '{template}'.",
-        "success": "✨ Stratégie de cache pour le modèle '{template}' mise à jour à '{strategy}'."
+        "success": "✨ Stratégie de cache pour le modèle '{template}' mise à jour en '{strategy}'."
       },
       "template": {
         "argument": "Le nom du modèle à mettre à jour"
@@ -91,12 +97,13 @@
         "argument": "La nouvelle stratégie de cache"
       },
       "start": "Mise à jour de la stratégie de cache pour le modèle '{template}'...",
-      "success": "Stratégie de cache pour le modèle '{template}' mise à jour à '{strategy}'",
-      "fail": "Échec de la mise à jour de la stratégie de cache pour le modèle '{template}'"
+      "success": "Stratégie de cache pour le modèle '{template}' mise à jour en '{strategy}'",
+      "fail": "Échec de la mise à jour de la stratégie de cache pour le modèle '{template}'",
+      "updating": "Mise à jour du cache..."
     },
     "check": {
-      "local": "Vérification de la configuration locale ou de monorepo...",
-      "global": "Configuration locale non trouvée. Vérification de la configuration globale..."
+      "local": "Vérification de la configuration locale ou du monorepo...",
+      "global": "Configuration locale introuvable. Vérification de la configuration globale..."
     },
     "found": {
       "local": "Configuration locale trouvée et utilisée à {path}.",
@@ -125,7 +132,8 @@
       "init": {
         "fail": "Échec de l'initialisation de la configuration."
       },
-      "read": "Échec de la lecture de la configuration à {path}."
+      "read": "Échec de la lecture de la configuration à {path}.",
+      "no_file_found": "Aucun fichier de configuration trouvé. Exécutez 'devkit config init' pour en créer un global, ou 'devkit config init --local' pour en créer un local."
     },
     "file": {
       "not_found": "Impossible de trouver le fichier '{fileName}'."
@@ -134,7 +142,7 @@
       "root": {
         "not_found": "Impossible de trouver la racine du projet contenant package.json."
       },
-      "file_not_found": "Fichier {file} non trouvé à l'emplacement {path}",
+      "file_not_found": "{file} non trouvé à l'emplacement {path}",
       "failed_to_update_project_name": "Échec de la mise à jour du nom du projet :"
     },
     "version": {
@@ -149,7 +157,7 @@
     "scaffolding": {
       "unexpected": "Une erreur inattendue s'est produite lors de l'échafaudage.",
       "language": {
-        "not_found": "Langue d'échafaudage non trouvée dans la configuration : '{language}'"
+        "not_found": "Langage d'échafaudage non trouvé dans la configuration : '{language}'"
       }
     },
     "command": {
@@ -170,7 +178,8 @@
       "generic": "Erreur Git"
     },
     "unexpected": "Une erreur inattendue s'est produite",
-    "unknown": "Une erreur inconnue s'est produite"
+    "unknown": "Une erreur inconnue s'est produite",
+    "language_config_not_found": "Langage d'échafaudage non trouvé dans la configuration : '{language}'"
   },
   "cache": {
     "clone": {
@@ -179,15 +188,15 @@
       "fail": "❌ Échec du clonage du dépôt."
     },
     "refresh": {
-      "start": "🔄 Rafraîchissement du modèle en cache...",
-      "success": "✅ Modèle rafraîchi avec succès !",
-      "fail": "❌ Échec du rafraîchissement du modèle."
+      "start": "🔄 Actualisation du modèle en cache...",
+      "success": "✅ Modèle actualisé avec succès !",
+      "fail": "❌ Échec de l'actualisation du modèle."
     },
     "use": {
       "info": "🚀 Utilisation du modèle en cache pour {repoName}."
     },
     "copy": {
-      "start": "📂 Copie du modèle en cache vers le répertoire du projet...",
+      "start": "📂 Copie du modèle en cache dans le répertoire du projet...",
       "success": "✅ Fichiers copiés avec succès !",
       "fail": "❌ Échec de la copie des fichiers depuis le cache."
     }
@@ -195,7 +204,7 @@
   "warning": {
     "no": {
       "local": {
-        "config": "Aucune configuration de projet locale trouvée. Utilisation des paramètres globaux ou par défaut."
+        "config": "Aucune configuration de projet local trouvée. Utilisation des paramètres globaux ou par défaut."
       }
     },
     "global": {
@@ -204,6 +213,20 @@
           "initialized": "Configuration globale non initialisée. Exécutez 'devkit config init' pour en créer une."
         }
       }
+    },
+    "no_config_found": "⚠️ Aucun fichier de configuration trouvé. Utilisation des paramètres par défaut."
+  },
+  "cli": {
+    "add_template": {
+      "description": "Ajouter un nouveau modèle à la configuration",
+      "options": {
+        "description": "Une brève description du modèle",
+        "alias": "Un alias court pour le modèle",
+        "cache": "La stratégie de cache pour le modèle",
+        "package_manager": "Le gestionnaire de paquets à utiliser pour le modèle"
+      },
+      "adding": "Ajout du modèle '{templateName}' à la configuration...",
+      "success": "Modèle '{templateName}' ajouté avec succès !"
     }
   }
 }

--- a/packages/devkit/src/commands/add-template.ts
+++ b/packages/devkit/src/commands/add-template.ts
@@ -1,0 +1,58 @@
+import {
+  type SetupCommandOptions,
+  type TemplateConfig,
+} from "#utils/configs/schema.js";
+import { saveCliConfig } from "#utils/configs/loader.js";
+import { t } from "#utils/internationalization/i18n.js";
+import { DevkitError } from "#utils/errors/base.js";
+import { handleErrorAndExit } from "#utils/errors/handler.js";
+import ora from "ora";
+import chalk from "chalk";
+
+export function setupAddTemplateCommand(options: SetupCommandOptions) {
+  const { program, config } = options;
+  program
+    .command("add-template <language> <templateName> <location>")
+    .description(t("cli.add_template.description"))
+    .alias("at")
+    .requiredOption(
+      "--description <string>",
+      t("cli.add_template.options.description"),
+    )
+    .option("--alias <string>", t("cli.add_template.options.alias"))
+    .option("--cache-strategy <string>", t("cli.add_template.options.cache"))
+    .option(
+      "--package-manager <string>",
+      t("cli.add_template.options.package_manager"),
+    )
+    .option("-g, --global", t("config.set.option.global"), false)
+    .action(async (language, templateName, location, cmdOptions) => {
+      const addSpinner = ora(chalk.cyan(t("cli.add_template.adding"))).start();
+      try {
+        const languageConfig = config.templates[language];
+        if (!languageConfig) {
+          throw new DevkitError(
+            t("error.language_config_not_found", { language }),
+          );
+        }
+
+        const newTemplate: TemplateConfig = {
+          description: cmdOptions.description,
+          location: location,
+          alias: cmdOptions.alias,
+          cacheStrategy: cmdOptions.cacheStrategy,
+          packageManager: cmdOptions.packageManager,
+        };
+
+        languageConfig.templates[templateName] = newTemplate;
+
+        await saveCliConfig(config, cmdOptions.global);
+
+        addSpinner.succeed(
+          chalk.green(t("cli.add_template.success", { templateName })),
+        );
+      } catch (error) {
+        handleErrorAndExit(error, addSpinner);
+      }
+    });
+}

--- a/packages/devkit/src/commands/config.ts
+++ b/packages/devkit/src/commands/config.ts
@@ -1,0 +1,181 @@
+import { Argument } from "commander";
+import {
+  saveLocalConfig,
+  saveGlobalConfig,
+  updateTemplateCacheStrategy,
+} from "#utils/configs/loader.js";
+import {
+  type CliConfig,
+  PackageManagers,
+  CONFIG_FILE_NAMES,
+  VALID_CACHE_STRATEGIES,
+  type PackageManager,
+  type CacheStrategy,
+  defaultCliConfig,
+  type SetupCommandOptions,
+} from "#utils/configs/schema.js";
+import { t } from "#utils/internationalization/i18n.js";
+import { DevkitError, ConfigError } from "#utils/errors/base.js";
+import { handleErrorAndExit } from "#utils/errors/handler.js";
+import fs from "fs-extra";
+import path from "path";
+import os from "os";
+import ora from "ora";
+import chalk from "chalk";
+import { setupAddTemplateCommand } from "./add-template.js";
+
+interface SetupNewCommandOptions extends SetupCommandOptions {
+  source: string;
+}
+
+function validateConfigValue(key: string, value: unknown) {
+  if (key === "defaultPackageManager") {
+    const validPackageManagers = Object.values(PackageManagers);
+    if (!validPackageManagers.includes(value as PackageManager)) {
+      throw new DevkitError(
+        t("error.invalid.value", {
+          key,
+          options: validPackageManagers.join(", "),
+        }),
+      );
+    }
+  } else if (key === "cacheStrategy") {
+    const validStrategies = VALID_CACHE_STRATEGIES;
+    if (!validStrategies.includes(value as CacheStrategy)) {
+      throw new DevkitError(
+        t("error.invalid.value", {
+          key,
+          options: validStrategies.join(", "),
+        }),
+      );
+    }
+  }
+}
+
+export function setupConfigCommand(options: SetupNewCommandOptions) {
+  const { program, config, source } = options;
+  const configCommand = program
+    .command("config")
+    .alias("cf")
+    .description(t("config.command.description"));
+
+  const configAliases: Record<string, keyof CliConfig["settings"]> = {
+    pm: "defaultPackageManager",
+    packageManager: "defaultPackageManager",
+    cache: "cacheStrategy",
+    cacheStrategy: "cacheStrategy",
+  };
+
+  const setCommandDescription = t("config.set.command.description", {
+    pmValues: Object.values(PackageManagers).join(", "),
+  });
+
+  configCommand
+    .command("set")
+    .description(setCommandDescription)
+    .addArgument(
+      new Argument("<key>", t("config.set.key.argument")).choices(
+        Object.keys(configAliases),
+      ),
+    )
+    .argument("<value>", t("config.set.value.argument"))
+    .option("-g, --global", t("config.set.option.global"), false)
+    .action(async (key, value, cmdOptions) => {
+      const spinner = ora(chalk.cyan(t("config.set.updating"))).start();
+      try {
+        if (source === "default") {
+          throw new DevkitError(t("error.config.no_file_found"));
+        }
+
+        const canonicalKey = configAliases[key];
+        if (!canonicalKey) {
+          throw new DevkitError(
+            t("error.invalid.key", {
+              key,
+              keys: Object.keys(configAliases).join(", "),
+            }),
+          );
+        }
+
+        validateConfigValue(canonicalKey, value);
+
+        const settings = { ...config.settings };
+        (settings[canonicalKey] as any) = value;
+
+        if (cmdOptions.global) {
+          await saveGlobalConfig(config);
+        } else {
+          await saveLocalConfig(config);
+        }
+
+        spinner.succeed(chalk.green(t("config.set.success")));
+      } catch (error) {
+        handleErrorAndExit(error, spinner);
+      }
+    });
+
+  configCommand
+    .command("init")
+    .alias("i")
+    .description(t("config.init.command.description"))
+    .option("-l, --local", t("config.init.option.local"), false)
+    .action(async (cmdOptions) => {
+      const isLocal = cmdOptions.local;
+      const configPath = isLocal
+        ? path.join(process.cwd(), CONFIG_FILE_NAMES[1])
+        : path.join(os.homedir(), CONFIG_FILE_NAMES[0]);
+
+      const spinner = ora(
+        chalk.cyan(t("config.init.initializing", { path: configPath })),
+      ).start();
+
+      try {
+        await fs.promises.stat(configPath);
+        throw new ConfigError(
+          t("error.config.exists", { path: configPath }),
+          configPath,
+        );
+      } catch (error: any) {
+        if (error.code !== "ENOENT") {
+          throw new ConfigError(t("error.config.init.fail"), configPath, {
+            cause: error,
+          });
+        }
+      }
+
+      if (isLocal) {
+        await saveLocalConfig({ ...defaultCliConfig });
+      } else {
+        await saveGlobalConfig({ ...defaultCliConfig });
+      }
+      spinner.succeed(chalk.green(t("config.init.success")));
+    });
+
+  configCommand
+    .command("cache")
+    .alias("c")
+    .description(t("config.cache.command.description"))
+    .argument("<templateName>", t("config.cache.template.argument"))
+    .addArgument(
+      new Argument("<strategy>", t("config.cache.strategy.argument")).choices(
+        VALID_CACHE_STRATEGIES,
+      ),
+    )
+    .action(async (templateName, strategy) => {
+      const spinner = ora(chalk.cyan(t("config.cache.updating"))).start();
+      try {
+        if (source === "default") {
+          throw new DevkitError(t("error.config.no_file_found"));
+        }
+        await updateTemplateCacheStrategy(templateName, strategy, config);
+        spinner.succeed(chalk.green(t("config.cache.success")));
+      } catch (error) {
+        handleErrorAndExit(error, spinner);
+      }
+    });
+
+  setupAddTemplateCommand({
+    program: configCommand,
+    config,
+  });
+}

--- a/packages/devkit/src/commands/new.ts
+++ b/packages/devkit/src/commands/new.ts
@@ -1,0 +1,44 @@
+import { type SetupCommandOptions } from "#utils/configs/schema.js";
+import { t } from "#utils/internationalization/i18n.js";
+
+export function setupNewCommand(options: SetupCommandOptions) {
+  const { program, config } = options;
+  const newCommand = program
+    .command("new")
+    .alias("nw")
+    .description(t("new.command.description"));
+
+  for (const [language, langConfig] of Object.entries(config.templates)) {
+    for (const [templateName, templateConfig] of Object.entries(
+      langConfig.templates,
+    )) {
+      newCommand
+        .command(templateName)
+        .alias(templateConfig.alias || "")
+        .description(
+          t("new.project.description", {
+            language: language,
+            template: templateName,
+            description: templateConfig.description,
+          }),
+        )
+        .argument("<projectName>", t("new.project.name.argument"))
+        .action(async (projectName) => {
+          const { scaffoldProject } = await import(
+            `@scaffolding/${language}.js`
+          );
+          await scaffoldProject({
+            projectName,
+            templateConfig,
+            packageManager:
+              templateConfig.packageManager ||
+              config.settings.defaultPackageManager,
+            cacheStrategy:
+              templateConfig.cacheStrategy ||
+              config.settings.cacheStrategy ||
+              "daily",
+          });
+        });
+    }
+  }
+}

--- a/packages/devkit/src/index.ts
+++ b/packages/devkit/src/index.ts
@@ -1,206 +1,33 @@
 #!/usr/bin/env node
 
-import { Command, Argument } from "commander";
+import { Command } from "commander";
 import {
-  saveLocalConfig,
-  saveGlobalConfig,
+  getLocaleFromConfigMinimal,
   loadUserConfig,
-  getLocaleFromConfig,
-  updateTemplateCacheStrategy,
 } from "#utils/configs/loader.js";
-import {
-  type CliConfig,
-  PackageManagers,
-  defaultCliConfig,
-  CONFIG_FILE_NAMES,
-  VALID_CACHE_STRATEGIES,
-  type PackageManager,
-  type CacheStrategy,
-} from "#utils/configs/schema.js";
 import { loadTranslations, t } from "#utils/internationalization/i18n.js";
 import ora from "ora";
 import chalk from "chalk";
 import { getProjectVersion } from "#utils/project.js";
-import fs from "fs-extra";
-import path from "path";
-import os from "os";
-import { DevkitError, ConfigError } from "#utils/errors/base.js";
 import { handleErrorAndExit } from "#utils/errors/handler.js";
+import { setupNewCommand } from "./commands/new.js";
+import { setupConfigCommand } from "./commands/config.js";
 
 const VERSION = await getProjectVersion();
-
-type SetupCommandOptions = {
-  program: Command;
-  config: CliConfig;
-};
-
-function validateConfigValue(key: string, value: unknown) {
-  if (key === "defaultPackageManager") {
-    const validPackageManagers = Object.values(PackageManagers);
-    if (!validPackageManagers.includes(value as PackageManager)) {
-      throw new DevkitError(
-        t("error.invalid.value", {
-          key,
-          options: validPackageManagers.join(", "),
-        }),
-      );
-    }
-  } else if (key === "cacheStrategy") {
-    const validStrategies = VALID_CACHE_STRATEGIES;
-    if (!validStrategies.includes(value as CacheStrategy)) {
-      throw new DevkitError(
-        t("error.invalid.value", {
-          key,
-          options: validStrategies.join(", "),
-        }),
-      );
-    }
-  }
-}
-
-function setupNewCommand(options: SetupCommandOptions) {
-  const { program, config } = options;
-  const newCommand = program
-    .command("new")
-    .alias("nw")
-    .description(t("new.command.description"));
-
-  for (const [language, langConfig] of Object.entries(config.templates)) {
-    for (const [templateName, templateConfig] of Object.entries(
-      langConfig.templates,
-    )) {
-      newCommand
-        .command(templateName)
-        .alias(templateConfig.alias || "")
-        .description(
-          t("new.project.description", {
-            language: language,
-            template: templateName,
-            description: templateConfig.description,
-          }),
-        )
-        .argument("<projectName>", t("new.project.name.argument"))
-        .action(async (projectName) => {
-          const { scaffoldProject } = await import(
-            `@scaffolding/${language}.js`
-          );
-          await scaffoldProject({
-            projectName,
-            templateConfig,
-            packageManager:
-              templateConfig.packageManager ||
-              config.settings.defaultPackageManager,
-            cacheStrategy:
-              templateConfig.cacheStrategy ||
-              config.settings.cacheStrategy ||
-              "daily",
-          });
-        });
-    }
-  }
-}
-
-function setupConfigCommand(options: SetupCommandOptions) {
-  const { program, config } = options;
-  const configCommand = program
-    .command("config")
-    .alias("cf")
-    .description(t("config.command.description"));
-
-  const configAliases: Record<string, keyof CliConfig["settings"]> = {
-    pm: "defaultPackageManager",
-    packageManager: "defaultPackageManager",
-    cache: "cacheStrategy",
-    cacheStrategy: "cacheStrategy",
-  };
-
-  const setCommandDescription = t("config.set.command.description", {
-    pmValues: Object.values(PackageManagers).join(", "),
-  });
-
-  configCommand
-    .command("set")
-    .description(setCommandDescription)
-    .addArgument(
-      new Argument("<key>", t("config.set.key.argument")).choices(
-        Object.keys(configAliases),
-      ),
-    )
-    .argument("<value>", t("config.set.value.argument"))
-    .option("-g, --global", t("config.set.option.global"), false)
-    .action(async (key, value, cmdOptions) => {
-      const canonicalKey = configAliases[key];
-
-      if (!canonicalKey) {
-        throw new DevkitError(
-          t("error.invalid.key", {
-            key,
-            keys: Object.keys(configAliases).join(", "),
-          }),
-        );
-      }
-
-      validateConfigValue(canonicalKey, value);
-
-      const settings = config.settings;
-      (settings[canonicalKey] as any) = value;
-
-      if (cmdOptions.global) {
-        await saveGlobalConfig(config);
-      } else {
-        await saveLocalConfig(config);
-      }
-    });
-
-  configCommand
-    .command("init")
-    .alias("i")
-    .description(t("config.init.command.description"))
-    .action(async () => {
-      const globalPath = path.join(
-        os.homedir(),
-        CONFIG_FILE_NAMES[0] || CONFIG_FILE_NAMES[1],
-      );
-      try {
-        await fs.promises.stat(globalPath);
-        throw new ConfigError(
-          t("error.config.exists", { path: globalPath }),
-          globalPath,
-        );
-      } catch (error: any) {
-        if (error.code !== "ENOENT") {
-          throw new ConfigError(t("error.config.init.fail"), globalPath, {
-            cause: error,
-          });
-        }
-      }
-      await saveGlobalConfig(defaultCliConfig as any);
-    });
-
-  configCommand
-    .command("cache")
-    .alias("c")
-    .description(t("config.cache.command.description"))
-    .argument("<templateName>", t("config.cache.template.argument"))
-    .addArgument(
-      new Argument("<strategy>", t("config.cache.strategy.argument")).choices(
-        VALID_CACHE_STRATEGIES,
-      ),
-    )
-    .action(async (templateName, strategy) => {
-      await updateTemplateCacheStrategy(templateName, strategy, config);
-    });
-}
 
 async function setupAndParse() {
   const program = new Command();
   const spinner = ora(chalk.cyan("Initializing CLI...")).start();
 
   try {
-    const locale = await getLocaleFromConfig(spinner);
-
+    const locale = await getLocaleFromConfigMinimal();
     await loadTranslations(locale);
-    const config = await loadUserConfig(spinner);
+
+    const { config, source } = await loadUserConfig(spinner);
+
+    if (source === "default") {
+      console.warn(t("warning.no_config_found"));
+    }
 
     spinner.succeed(chalk.green(t("program.initialized")));
 
@@ -212,7 +39,7 @@ async function setupAndParse() {
       .helpOption("-h, --help", t("help.description"));
 
     setupNewCommand({ program, config });
-    setupConfigCommand({ program, config });
+    setupConfigCommand({ program, config, source });
 
     program.parse();
   } catch (error) {

--- a/packages/devkit/src/utils/configs/schema.ts
+++ b/packages/devkit/src/utils/configs/schema.ts
@@ -1,3 +1,5 @@
+import type { Command } from "commander";
+
 export const ProgrammingLanguage = {
   Javascript: "Javascript",
 } as const;
@@ -35,6 +37,8 @@ export const TextLanguages = {
   French: "fr",
 } as const;
 export type TextLanguageValues = ValuesOf<typeof TextLanguages>;
+// oxlint-disable-next-line no-useless-spread
+export const SUPPORTED_LANGUAGES = [...Object.values(TextLanguages)] as const;
 
 export interface TemplateConfig {
   description: string;
@@ -70,6 +74,11 @@ export interface CliConfig {
     cacheStrategy?: CacheStrategy;
     language: TextLanguageValues;
   };
+}
+
+export interface SetupCommandOptions {
+  program: Command;
+  config: CliConfig;
 }
 
 export const defaultCliConfig: CliConfig = {


### PR DESCRIPTION
## Description

This PR introduces the new `add-template` command, enabling users to define and save templates directly via the command line. This functionality simplifies the process of adding new language- or framework-specific templates to the CLI's configuration, improving flexibility and user experience.

The feature is built on the existing configuration loader and file-finding utilities, ensuring it works seamlessly with both local project and global configurations.

Fixes # (issue)

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] This change requires a documentation update

## Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules