### PR TITLE
feat: add list command to display available templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Built to fit the modern developer workflow, `dk` seamlessly integrates into mono
 
 The Dev Kit CLI streamlines development workflows in various environments:
 
-- **Globally Installed CLI:** Install `dk` globally for a universal scaffolding tool on your machine.
+- **Globally Installed CLI:** Install `@itwibrc/devkit` globally for a universal scaffolding tool on your machine.
 - **Monorepo:** A single configuration file at the root can manage settings and templates for all projects, ensuring consistency across your entire codebase.
 - **Multiple Repositories:** Each project can have its own `.devkitrc` file for unique settings, allowing for flexible project management.
 
@@ -53,16 +53,16 @@ Install Dev Kit globally using your preferred package manager.
 
 ```bash
 # using bun
-bun install -g devkit
+bun install -g @itwibrc/devkit
 
 # using npm
-npm install -g devkit
+npm install -g @itwibrc/devkit
 
 # using pnpm
-pnpm install -g devkit
+pnpm install -g @itwibrc/devkit
 
 # using yarn
-yarn global add devkit
+yarn global add @itwibrc/devkit
 ```
 
 ### Verify Installation
@@ -103,6 +103,18 @@ You must provide a `description` using the `--description` flag. Other options l
 dk add-template javascript react-ts-template https://github.com/my-user/my-react-ts-template --description "My custom React TS template"
 ```
 
+### List available templates
+
+The `list` command allows you to view all available templates defined in your configuration.
+
+```bash
+# List all templates categorized by language
+dk list
+
+# List templates for a specific language (e.g., 'javascript')
+dk list javascript
+```
+
 ### Manage your CLI configuration
 
 Use the `config set` command to update your `.devkitrc` file.
@@ -133,6 +145,7 @@ For a faster workflow, the following commands have shortcuts:
 - `config` -\> `cf`
 - `cache` -\> `c`
 - `add-template` -\> `at`
+- `list` -\> `ls`
 
 ---
 
@@ -208,7 +221,6 @@ For a better developer experience, add a `$schema` property for auto-completion 
     "javascript": {
       "templates": {
         "react": {
-          "description": "A template from a GitHub repository",
           "location": "https://github.com/IT-WIBRC/react-ts-template"
         }
       }
@@ -216,7 +228,6 @@ For a better developer experience, add a `$schema` property for auto-completion 
     "typescript": {
       "templates": {
         "vue": {
-          "description": "A template from a GitHub repository",
           "location": "{pm} create vue@latest"
         }
       }

--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,7 @@ This document tracks all planned tasks, bugs, and future ideas for the Dev Kit p
 - [ ] Find a way to test the templates
 - [x] Refactor the `new` command to accept option to select a template
 - [x] Warn user to not use already used names for templates and tell we only support js templates containing nodejs related templates (No need anymore as user can create custom templates or edit existing ones)
-- [ ] Add a command to list all available templates
+- [x] Add a command to list all available templates
 - [ ] Add a command to remove a template
 - [ ] Add a command to update a template
 - [ ] Add a command to update the CLI itself

--- a/packages/devkit/locales/en.json
+++ b/packages/devkit/locales/en.json
@@ -24,6 +24,19 @@
       "fail": "❌ Failed to scaffold project: {error}"
     }
   },
+  "list": {
+    "command": {
+      "description": "List all available templates in the configuration.",
+      "language": {
+        "argument": "The language to filter templates by"
+      }
+    },
+    "templates": {
+      "loading": "Loading templates...",
+      "not_found": "No templates found in the configuration file.",
+      "header": "Available Templates:"
+    }
+  },
   "version": {
     "description": "Output the current version of the CLI."
   },

--- a/packages/devkit/locales/fr.json
+++ b/packages/devkit/locales/fr.json
@@ -1,6 +1,6 @@
 {
   "program": {
-    "description": "Une puissante boîte à outils pour la création de nouveaux projets.",
+    "description": "Une puissante boîte à outils pour le développement pour l'initialisation de nouveaux projets.",
     "initialized": "CLI initialisée avec succès."
   },
   "new": {
@@ -9,32 +9,45 @@
     },
     "project": {
       "language": {
-        "argument": "Le langage de programmation du modèle (ex. : 'react', 'node')"
+        "argument": "Le langage de programmation du modèle (par exemple, 'react', 'node')"
       },
       "name": {
         "argument": "Le nom de votre nouveau projet"
       },
       "template": {
         "option": {
-          "description": "Le nom du modèle à utiliser (ex. : 'ts', 'simple-api')"
+          "description": "Le nom du modèle à utiliser (par exemple, 'ts', 'simple-api')"
         }
       },
-      "scaffolding": "Génération du projet '{projectName}' avec le modèle '{template}'...",
+      "scaffolding": "Initialisation du projet '{projectName}' avec le modèle '{template}'...",
       "success": "✅ Projet '{projectName}' créé avec succès !",
-      "fail": "❌ Échec de la création du projet : {error}"
+      "fail": "❌ Échec de l'initialisation du projet : {error}"
+    }
+  },
+  "list": {
+    "command": {
+      "description": "Lister tous les modèles disponibles dans la configuration.",
+      "language": {
+        "argument": "Le langage pour filtrer les modèles"
+      }
+    },
+    "templates": {
+      "loading": "Chargement des modèles...",
+      "not_found": "Aucun modèle trouvé dans le fichier de configuration.",
+      "header": "Modèles disponibles :"
     }
   },
   "version": {
-    "description": "Affiche la version actuelle de la CLI."
+    "description": "Afficher la version actuelle de la CLI."
   },
   "help": {
-    "description": "Affiche l'aide pour une commande."
+    "description": "Afficher l'aide pour une commande."
   },
   "scaffolding": {
     "project": {
-      "start": "Génération du projet {language} : {project}",
+      "start": "Initialisation du projet {language} : {project}",
       "success": "✅ Projet {language} '{project}' créé avec succès !",
-      "fail": "❌ Échec de la génération du projet {language} : {error}"
+      "fail": "❌ Échec de l'initialisation du projet {language} : {error}"
     },
     "copy": {
       "start": "📂 Copie des fichiers du modèle local...",
@@ -53,7 +66,7 @@
     },
     "complete": {
       "success": "\n🚀 Projet créé avec succès ! 🎉",
-      "next_steps": "\n| Prochaines étapes :"
+      "next_steps": "\n| Prochaines étapes :\n"
     }
   },
   "config": {
@@ -62,7 +75,7 @@
     },
     "set": {
       "command": {
-        "description": "Définit une valeur de configuration. \n\nClés disponibles :\n  pm, packageManager      - Définit le gestionnaire de paquets par défaut à utiliser pour les nouveaux projets.\n                          Valeurs possibles : {pmValues}\n  cache, cacheStrategy    - Définit le comportement de mise en cache global pour les modèles distants.\n                          Valeurs possibles : 'always-refresh', 'never-refresh', 'daily'\n  language, lg            - Définit la langue de la CLI. Valeurs possibles : 'en', 'fr'\n"
+        "description": "Définir une valeur de configuration. \n\nClés disponibles :\n  pm, packageManager      - Définit le gestionnaire de paquets par défaut à utiliser pour les nouveaux projets.\n                          Valeurs possibles : {pmValues}\n  cache, cacheStrategy    - Définit le comportement de mise en cache global pour les modèles distants.\n                          Valeurs possibles : 'always-refresh', 'never-refresh', 'daily'\n  language, lg            - Définit la langue de la CLI. Valeurs possibles : 'en', 'fr'\n"
       },
       "key": {
         "argument": "La clé de configuration à définir"
@@ -81,7 +94,7 @@
         "description": "Initialise un fichier de configuration global avec les paramètres par défaut."
       },
       "start": "Initialisation de la configuration globale à {path}...",
-      "success": "Fichier de configuration global créé avec succès !",
+      "success": "Fichier de configuration globale créé avec succès !",
       "fail": "Échec de l'initialisation de la configuration globale.",
       "initializing": "Initialisation de la configuration...",
       "option": {
@@ -90,7 +103,7 @@
     },
     "update": {
       "start": "Mise à jour du paramètre : {key}...",
-      "success": "✅ '{key}' a été mis à jour avec succès vers '{value}' !",
+      "success": "✅ {key} mis à jour avec succès à {value} !",
       "fail": "❌ Échec de la mise à jour du paramètre."
     },
     "cache": {
@@ -98,7 +111,7 @@
         "description": "Mettre à jour la stratégie de cache pour un modèle spécifique.",
         "start": "Mise à jour de la stratégie de cache pour le modèle '{template}'...",
         "fail": "❌ Échec de la mise à jour de la stratégie de cache pour le modèle '{template}'.",
-        "success": "✨ Stratégie de cache pour le modèle '{template}' mise à jour vers '{strategy}'."
+        "success": "✨ Stratégie de cache pour le modèle '{template}' mise à jour en '{strategy}'."
       },
       "template": {
         "argument": "Le nom du modèle à mettre à jour"
@@ -107,7 +120,7 @@
         "argument": "La nouvelle stratégie de cache"
       },
       "start": "Mise à jour de la stratégie de cache pour le modèle '{template}'...",
-      "success": "Stratégie de cache pour le modèle '{template}' mise à jour vers '{strategy}'",
+      "success": "Stratégie de cache pour le modèle '{template}' mise à jour en '{strategy}'",
       "fail": "Échec de la mise à jour de la stratégie de cache pour le modèle '{template}'",
       "updating": "Mise à jour du cache..."
     },
@@ -117,7 +130,7 @@
     },
     "found": {
       "local": "Configuration locale trouvée et utilisée à {path}.",
-      "global": "Aucune configuration locale trouvée. Utilisation de la configuration globale à {path}."
+      "global": "Pas de configuration locale trouvée. Utilisation de la configuration globale à {path}."
     },
     "not": {
       "found": {
@@ -153,7 +166,7 @@
         "not_found": "Impossible de trouver la racine du projet contenant package.json."
       },
       "file_not_found": "{file} non trouvé à {path}",
-      "failed_to_update_project_name": "Échec de la mise à jour du nom de projet :"
+      "failed_to_update_project_name": "Échec de la mise à jour du nom du projet :"
     },
     "version": {
       "read_fail": "Échec de la lecture de la version de package.json."
@@ -165,9 +178,9 @@
       "message": "Erreur d'installation :"
     },
     "scaffolding": {
-      "unexpected": "Une erreur inattendue est survenue pendant la génération.",
+      "unexpected": "Une erreur inattendue est survenue lors de l'initialisation.",
       "language": {
-        "not_found": "Langue de génération non trouvée dans la configuration : '{language}'"
+        "not_found": "Langage d'initialisation non trouvé dans la configuration : '{language}'"
       }
     },
     "command": {
@@ -189,7 +202,7 @@
     },
     "unexpected": "Une erreur inattendue est survenue",
     "unknown": "Une erreur inconnue est survenue",
-    "language_config_not_found": "Langue de configuration non trouvée : '{language}'"
+    "language_config_not_found": "Langage d'initialisation non trouvé dans la configuration : '{language}'"
   },
   "cache": {
     "clone": {
@@ -198,15 +211,15 @@
       "fail": "❌ Échec du clonage du dépôt."
     },
     "refresh": {
-      "start": "🔄 Rafraîchissement du modèle en cache...",
+      "start": "🔄 Rafraîchissement du modèle mis en cache...",
       "success": "✅ Modèle rafraîchi avec succès !",
       "fail": "❌ Échec du rafraîchissement du modèle."
     },
     "use": {
-      "info": "🚀 Utilisation du modèle en cache pour {repoName}."
+      "info": "🚀 Utilisation du modèle mis en cache pour {repoName}."
     },
     "copy": {
-      "start": "📂 Copie du modèle en cache vers le répertoire du projet...",
+      "start": "📂 Copie du modèle mis en cache vers le répertoire du projet...",
       "success": "✅ Fichiers copiés avec succès !",
       "fail": "❌ Échec de la copie des fichiers depuis le cache."
     }
@@ -214,7 +227,7 @@
   "warning": {
     "no": {
       "local": {
-        "config": "Aucune configuration de projet locale trouvée. Utilisation des paramètres globaux ou par défaut."
+        "config": "Aucune configuration de projet local trouvée. Utilisation des paramètres globaux ou par défaut."
       }
     },
     "global": {

--- a/packages/devkit/src/commands/list.ts
+++ b/packages/devkit/src/commands/list.ts
@@ -1,0 +1,62 @@
+import { type SetupCommandOptions } from "#utils/configs/schema.js";
+import { t } from "#utils/internationalization/i18n.js";
+import { handleErrorAndExit } from "#utils/errors/handler.js";
+import { DevkitError } from "#utils/errors/base.js";
+import ora from "ora";
+import chalk from "chalk";
+
+export function setupListCommand(options: SetupCommandOptions) {
+  const { program, config } = options;
+  program
+    .command("list")
+    .alias("ls")
+    .description(t("list.command.description"))
+    .argument("[language]", t("list.command.language.argument"), "")
+    .action(async (language) => {
+      const spinner = ora(t("list.templates.loading")).start();
+
+      try {
+        const templates = config.templates;
+        if (Object.keys(templates).length === 0) {
+          spinner.info(chalk.yellow(t("list.templates.not_found")));
+          return;
+        }
+
+        spinner.stop();
+        console.log("\n", chalk.bold(t("list.templates.header")));
+
+        if (language) {
+          const languageTemplates = templates[language];
+          if (!languageTemplates) {
+            throw new DevkitError(
+              t("error.language_config_not_found", { language }),
+            );
+          }
+
+          console.log(`\n${chalk.blue.bold(language.toUpperCase())}:`);
+          for (const [templateName, templateConfig] of Object.entries(
+            languageTemplates.templates,
+          )) {
+            const description = templateConfig.description
+              ? `- ${templateConfig.description}`
+              : "";
+            console.log(`  - ${chalk.green(templateName)} ${description}`);
+          }
+        } else {
+          for (const [lang, langTemplates] of Object.entries(templates)) {
+            console.log(`\n${chalk.blue.bold(lang.toUpperCase())}:`);
+            for (const [templateName, templateConfig] of Object.entries(
+              langTemplates.templates,
+            )) {
+              const description = templateConfig.description
+                ? `- ${templateConfig.description}`
+                : "";
+              console.log(`  - ${chalk.green(templateName)} ${description}`);
+            }
+          }
+        }
+      } catch (error) {
+        handleErrorAndExit(error, spinner);
+      }
+    });
+}

--- a/packages/devkit/src/index.ts
+++ b/packages/devkit/src/index.ts
@@ -12,6 +12,7 @@ import { getProjectVersion } from "#utils/project.js";
 import { handleErrorAndExit } from "#utils/errors/handler.js";
 import { setupNewCommand } from "./commands/new.js";
 import { setupConfigCommand } from "./commands/config.js";
+import { setupListCommand } from "./commands/list.js";
 
 const VERSION = await getProjectVersion();
 
@@ -44,6 +45,7 @@ async function setupAndParse() {
 
     setupNewCommand({ program, config });
     setupConfigCommand({ program, config, source });
+    setupListCommand({ program, config });
 
     program.parse();
   } catch (error) {


### PR DESCRIPTION
## Description

This PR introduces a new `list` command to improve template discoverability for users. The new command allows developers to view all available templates in their configuration directly from the command line, eliminating the need to manually inspect the `.devkitrc` file.

The command supports an optional language argument to filter the list, making it easy to find templates for a specific language. All messages and descriptions for the new command are fully internationalized.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules