### PR TITLE
feat(command): add a command to update a template (name and options)

### DIFF
--- a/.devkitrc.json
+++ b/.devkitrc.json
@@ -4,7 +4,8 @@
       "templates": {
         "simple": {
           "description": "A basic Node.js starter project.",
-          "location": "./templates/nodejs/simple"
+          "location": "./templates/nodejs/simple",
+          "alias": "sp"
         },
         "vue": {
           "description": "An official Vue.js project.",
@@ -20,6 +21,10 @@
           "description": "An official Nest.js project.",
           "location": "{pm} install -g @nestjs/cli && nest new"
         },
+        "vue-large": {
+          "description": "A lightweight project for showcase websites.",
+          "location": "https://github.com/CMGGEvolution/template-vue.git"
+        },
         "medium": {
           "description": "A more complex project with a pre-configured database.",
           "location": "https://github.com/my-user/my-node-template.git"
@@ -28,9 +33,10 @@
           "description": "A lightweight project for showcase websites.",
           "location": "https://github.com/CMGGEvolution/template-vue.git"
         },
-        "my-custom-template": {
+        "custom-template": {
           "description": "A template for my team's projects.",
-          "location": "/path/to/my/local/template-folder"
+          "location": "/path/to/my/local/template-folder",
+          "alias": "mct"
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -105,6 +105,28 @@ You must provide a `description` using the `--description` flag. Other options l
 dk add-template javascript react-ts-template https://github.com/my-user/my-react-ts-template --description "My custom React TS template"
 ```
 
+### Update a template's configuration
+
+The `update` command allows you to modify an existing template's properties. This is useful for changing a template's alias, location, or associated package manager. You can update one or more properties in a single command.
+
+You can also update the template's name using the `--new-name` flag, which is useful for correcting typos or renaming a template.
+
+- **Global:** Use the `--global` flag to update the template in your global (`~/.devkitrc`) file.
+- **Local:** It updates the `.devkitrc` file in the root of your current project.
+
+<!-- end list -->
+
+```bash
+# Update the description and alias for a template
+dk update javascript my-template --description "A new and improved description" --alias "my-alias"
+
+# Update a template's package manager and remove its alias
+dk update javascript my-template --package-manager bun --alias null
+
+# Change a template's name and its description in a single command
+dk update javascript my-template --new-name my-cool-template --description "A newly renamed template"
+```
+
 ### Remove an existing template from your configuration
 
 The `remove-template` command allows you to delete a template from your configuration file. You can identify the template by its name or a configured alias.
@@ -163,6 +185,7 @@ For a faster workflow, the following commands have shortcuts:
 - `init` -\> `i`
 - `config` -\> `cf`
 - `cache` -\> `c`
+- `update` -\> `up`
 - `add-template` -\> `at`
 - `remove-template` -\> `rt`
 - `list` -\> `ls`

--- a/TODO.md
+++ b/TODO.md
@@ -22,12 +22,11 @@ This document tracks all planned tasks, bugs, and future ideas for the Dev Kit p
 - [x] Refactor the `new` command to accept option to select a template
 - [x] Warn user to not use already used names for templates and tell we only support js templates containing nodejs related templates (No need anymore as user can create custom templates or edit existing ones)
 - [x] Add a command to list all available templates
-- [ ] Add a command to remove a template
-- [ ] Add a command to update a template
+- [x] Add a command to remove a template
+- [x] Add a command to update a template (name and options)
+- [ ] Refactor the `set` command so support the setting of many config at once and also with possibility of
+- [ ] Improve the config management (Share config get on mounted and get it later only when necessary)
 - [ ] Add a command to update the CLI itself
-- [ ] Add a command to update the templates
-- [ ] Add a command to update the configuration
-- [ ] Add a command to update the language configuration
 - [ ] Add integration tests in addition to unit tests (reproduce monorepo, multi repo and bare repository)
 - [x] Enable copilot reviews for the project on GitHub (Impossible as it's not free as expected)
 

--- a/packages/devkit/locales/en.json
+++ b/packages/devkit/locales/en.json
@@ -107,20 +107,39 @@
     },
     "init": {
       "command": {
-        "description": "Initializes a global configuration file with default settings."
+        "description": "Initializes a configuration file with default settings."
       },
-      "start": "Initializing global config at {path}...",
-      "success": "Global configuration file created successfully!",
-      "fail": "Failed to initialize global config.",
+      "start": "Initializing config...",
+      "success": "Configuration file created successfully!",
+      "fail": "Failed to initialize config.",
       "initializing": "Initializing configuration...",
       "option": {
-        "local": "Initialize a local configuration file instead of a global one."
+        "local": "Initialize a local configuration file instead of a global one.",
+        "global": "Initialize a global configuration file instead of a local one."
       }
     },
     "update": {
-      "start": "Updating setting: {key}...",
-      "success": "✅ Successfully updated {key} to {value}!",
-      "fail": "❌ Failed to update setting."
+      "command": {
+        "description": "Update properties of a template, such as its alias, description, or location."
+      },
+      "language": {
+        "argument": "The programming language of the template to update."
+      },
+      "template": {
+        "argument": "The name or alias of the template to update."
+      },
+      "option": {
+        "new_name": "A new name for the template.",
+        "description": "A new brief description for the template.",
+        "alias": "A new alias for the template.",
+        "location": "A new location for the template.",
+        "cache_strategy": "A new cache strategy for the template.",
+        "package_manager": "A new package manager for the template.",
+        "global": "Update the template in the global configuration instead of the local one."
+      },
+      "updating": "Updating template '{templateName}' in configuration...",
+      "success": "✅ Template '{templateName}' updated successfully!",
+      "success_name": "✅ Template '{oldName}' updated to '{newName}' successfully!"
     },
     "cache": {
       "command": {
@@ -160,7 +179,8 @@
       "value": "Invalid value for {key}. Valid options are: {options}",
       "command": "Invalid command in configuration: '{command}'",
       "cache_strategy": "Invalid cache strategy: '{value}'. Valid options are: {options}",
-      "package_manager": "Invalid package manager: '{value}'. Valid options are: {options}"
+      "package_manager": "Invalid package manager: '{value}'. Valid options are: {options}",
+      "remove_required": "Cannot remove a required property: '{key}'."
     },
     "config": {
       "parse": "Failed to parse {file}. Using default configuration.",
@@ -171,17 +191,18 @@
       },
       "global": {
         "not": {
-          "found": "Global configuration file not found. Run 'devkit config init' to create one."
+          "found": "Global configuration file not found. Run 'devkit config init --global' to create one."
         }
       },
       "local": {
         "not": {
-          "found": "No local configuration file found."
+          "found": "No local configuration file found. Run 'devkit config init --local' to create one."
         }
       },
       "generic": "Configuration error",
       "init": {
-        "fail": "Failed to initialize configuration."
+        "fail": "Failed to initialize configuration.",
+        "local_and_global": "Cannot use both --local and --global flags at the same time."
       },
       "read": "Failed to read configuration at {path}.",
       "no_file_found": "No configuration file found. Run 'devkit config init' to create a global one, or 'devkit config init --local' to create a local one.",

--- a/packages/devkit/locales/fr.json
+++ b/packages/devkit/locales/fr.json
@@ -1,56 +1,56 @@
 {
   "program": {
-    "description": "Une boîte à outils puissante pour la création de nouveaux projets.",
-    "initialized": "CLI initialisée avec succès."
+    "description": "Un devkit puissant pour le scaffolding de nouveaux projets.",
+    "initialized": "CLI initialisé avec succès."
   },
   "new": {
     "command": {
-      "description": "Créer un nouveau projet à partir d'un modèle"
+      "description": "Créer un nouveau projet à partir d'un template"
     },
     "project": {
       "language": {
-        "argument": "Le langage de programmation du modèle (par exemple, 'react', 'node')"
+        "argument": "Le langage de programmation du template (par exemple, 'react', 'node')"
       },
       "name": {
         "argument": "Le nom de votre nouveau projet"
       },
       "template": {
         "option": {
-          "description": "Le nom du modèle à utiliser (par exemple, 'ts', 'simple-api')"
+          "description": "Le nom du template à utiliser (par exemple, 'ts', 'simple-api')"
         }
       },
-      "scaffolding": "Création du projet '{projectName}' avec le modèle '{template}'...",
+      "scaffolding": "Scaffolding du projet '{projectName}' avec le template '{template}'...",
       "success": "✅ Projet '{projectName}' créé avec succès !",
-      "fail": "❌ Échec de la création du projet : {error}"
+      "fail": "❌ Échec du scaffolding du projet : {error}"
     }
   },
   "list": {
     "command": {
-      "description": "Lister tous les modèles disponibles dans la configuration.",
+      "description": "Lister tous les templates disponibles dans la configuration.",
       "language": {
-        "argument": "Le langage pour filtrer les modèles"
+        "argument": "Le langage pour filtrer les templates"
       }
     },
     "templates": {
-      "loading": "Chargement des modèles...",
-      "not_found": "Aucun modèle trouvé dans le fichier de configuration.",
-      "header": "Modèles disponibles :"
+      "loading": "Chargement des templates...",
+      "not_found": "Aucun template trouvé dans le fichier de configuration.",
+      "header": "Templates disponibles :"
     }
   },
   "remove_template": {
     "command": {
-      "description": "Supprimer un modèle de la configuration."
+      "description": "Supprimer un template de la configuration."
     },
-    "start": "Suppression du modèle de la configuration...",
-    "success": "✅ Modèle '{templateName}' pour '{language}' supprimé avec succès !",
+    "start": "Suppression du template de la configuration...",
+    "success": "✅ Template '{templateName}' pour '{language}' supprimé avec succès !",
     "language": {
-      "argument": "Le langage de programmation du modèle à supprimer."
+      "argument": "Le langage de programmation du template à supprimer."
     },
     "name": {
-      "argument": "Le nom ou l'alias du modèle à supprimer."
+      "argument": "Le nom ou l'alias du template à supprimer."
     },
     "option": {
-      "global": "Supprimer le modèle de la configuration globale au lieu de la configuration locale."
+      "global": "Supprimer le template de la configuration globale au lieu de la configuration locale."
     }
   },
   "version": {
@@ -61,19 +61,19 @@
   },
   "scaffolding": {
     "project": {
-      "start": "Création du projet {language} : {project}",
+      "start": "Scaffolding du projet {language} : {project}",
       "success": "✅ Projet {language} '{project}' créé avec succès !",
-      "fail": "❌ Échec de la création du projet {language} : {error}"
+      "fail": "❌ Échec du scaffolding du projet {language} : {error}"
     },
     "copy": {
-      "start": "📂 Copie des fichiers du modèle local...",
-      "success": "✅ Modèle local copié avec succès !",
-      "fail": "❌ Échec de la copie du modèle local."
+      "start": "📂 Copie des fichiers du template local...",
+      "success": "✅ Template local copié avec succès !",
+      "fail": "❌ Échec de la copie du template local."
     },
     "run": {
-      "start": "📦 Exécution de la commande CLI officielle : {command}...",
-      "success": "✅ Commande CLI officielle exécutée avec succès !",
-      "fail": "❌ Échec de l'exécution de la commande CLI officielle."
+      "start": "📦 Exécution de la commande officielle de la CLI : {command}...",
+      "success": "✅ Commande officielle de la CLI exécutée avec succès !",
+      "fail": "❌ Échec de l'exécution de la commande officielle de la CLI."
     },
     "install": {
       "start": "📦 Installation des dépendances avec {pm}...",
@@ -91,7 +91,7 @@
     },
     "set": {
       "command": {
-        "description": "Définir une valeur de configuration. \n\nClés disponibles :\n  pm, packageManager      - Définit le gestionnaire de paquets par défaut à utiliser pour les nouveaux projets.\n                          Valeurs possibles : {pmValues}\n  cache, cacheStrategy    - Définit le comportement de mise en cache global pour les modèles distants.\n                          Valeurs possibles : 'always-refresh', 'never-refresh', 'daily'\n  language, lg            - Définit la langue de la CLI. Valeurs possibles : 'en', 'fr'\n"
+        "description": "Définir une valeur de configuration. \n\nClés disponibles :\n  pm, packageManager      - Définit le gestionnaire de paquets par défaut à utiliser pour les nouveaux projets.\n                          Valeurs possibles : {pmValues}\n  cache, cacheStrategy    - Définit le comportement de mise en cache globale pour les templates distants.\n                          Valeurs possibles : 'always-refresh', 'never-refresh', 'daily'\n  language, lg            - Définit le langage de la CLI. Valeurs possibles : 'en', 'fr'\n"
       },
       "key": {
         "argument": "La clé de configuration à définir"
@@ -100,48 +100,67 @@
         "argument": "La nouvelle valeur pour la clé"
       },
       "option": {
-        "global": "Mettre à jour la configuration globale au lieu de la locale."
+        "global": "Mettre à jour la configuration globale au lieu de la configuration locale."
       },
       "updating": "Mise à jour de la configuration...",
       "success": "Configuration mise à jour avec succès."
     },
     "init": {
       "command": {
-        "description": "Initialise un fichier de configuration global avec les paramètres par défaut."
+        "description": "Initialise un fichier de configuration avec les paramètres par défaut."
       },
-      "start": "Initialisation de la configuration globale à {path}...",
-      "success": "Fichier de configuration globale créé avec succès !",
-      "fail": "Échec de l'initialisation de la configuration globale.",
+      "start": "Initialisation de la configuration...",
+      "success": "Fichier de configuration créé avec succès !",
+      "fail": "Échec de l'initialisation de la configuration.",
       "initializing": "Initialisation de la configuration...",
       "option": {
-        "local": "Initialiser un fichier de configuration local au lieu d'un global."
+        "local": "Initialiser un fichier de configuration locale au lieu d'un fichier global.",
+        "global": "Initialiser un fichier de configuration globale au lieu d'un fichier local."
       }
     },
     "update": {
-      "start": "Mise à jour du paramètre : {key}...",
-      "success": "✅ '{key}' mis à jour avec succès à '{value}' !",
-      "fail": "❌ Échec de la mise à jour du paramètre."
+      "command": {
+        "description": "Mettre à jour les propriétés d'un template, comme son alias, sa description ou son emplacement."
+      },
+      "language": {
+        "argument": "Le langage de programmation du template à mettre à jour."
+      },
+      "template": {
+        "argument": "Le nom ou l'alias du template à mettre à jour."
+      },
+      "option": {
+        "new_name": "Un nouveau nom pour le template.",
+        "description": "Une nouvelle brève description pour le template.",
+        "alias": "Un nouvel alias pour le template.",
+        "location": "Un nouvel emplacement pour le template.",
+        "cache_strategy": "Une nouvelle stratégie de cache pour le template.",
+        "package_manager": "Un nouveau gestionnaire de paquets pour le template.",
+        "global": "Mettre à jour le template dans la configuration globale au lieu de la configuration locale."
+      },
+      "updating": "Mise à jour du template '{templateName}' dans la configuration...",
+      "success": "✅ Template '{templateName}' mis à jour avec succès !",
+      "success_name": "✅ Template '{oldName}' mis à jour en '{newName}' avec succès !"
     },
     "cache": {
       "command": {
-        "description": "Mettre à jour la stratégie de cache pour un modèle spécifique.",
-        "start": "Mise à jour de la stratégie de cache pour le modèle '{template}'...",
-        "fail": "❌ Échec de la mise à jour de la stratégie de cache pour le modèle '{template}'.",
-        "success": "✨ Stratégie de cache pour le modèle '{template}' mise à jour en '{strategy}'."
+        "description": "Mettre à jour la stratégie de cache pour un template spécifique.",
+        "start": "Mise à jour de la stratégie de cache pour le template '{template}'...",
+        "fail": "❌ Échec de la mise à jour de la stratégie de cache pour le template '{template}'.",
+        "success": "✨ Stratégie de cache pour le template '{template}' mise à jour en '{strategy}'."
       },
       "template": {
-        "argument": "Le nom du modèle à mettre à jour"
+        "argument": "Le nom du template à mettre à jour"
       },
       "strategy": {
         "argument": "La nouvelle stratégie de cache"
       },
-      "start": "Mise à jour de la stratégie de cache pour le modèle '{template}'...",
-      "success": "Stratégie de cache pour le modèle '{template}' mise à jour en '{strategy}'",
-      "fail": "Échec de la mise à jour de la stratégie de cache pour le modèle '{template}'",
+      "start": "Mise à jour de la stratégie de cache pour le template '{template}'...",
+      "success": "Stratégie de cache pour le template '{template}' mise à jour en '{strategy}'",
+      "fail": "Échec de la mise à jour de la stratégie de cache pour le template '{template}'",
       "updating": "Mise à jour du cache..."
     },
     "check": {
-      "local": "Vérification de la configuration locale ou du monorepo...",
+      "local": "Vérification de la configuration locale ou monorepo...",
       "global": "Configuration locale non trouvée. Vérification de la configuration globale..."
     },
     "found": {
@@ -160,7 +179,8 @@
       "value": "Valeur invalide pour {key}. Les options valides sont : {options}",
       "command": "Commande invalide dans la configuration : '{command}'",
       "cache_strategy": "Stratégie de cache invalide : '{value}'. Les options valides sont : {options}",
-      "package_manager": "Gestionnaire de paquets invalide : '{value}'. Les options valides sont : {options}"
+      "package_manager": "Gestionnaire de paquets invalide : '{value}'. Les options valides sont : {options}",
+      "remove_required": "Impossible de supprimer une propriété requise : '{key}'."
     },
     "config": {
       "parse": "Échec de l'analyse de {file}. Utilisation de la configuration par défaut.",
@@ -171,17 +191,18 @@
       },
       "global": {
         "not": {
-          "found": "Fichier de configuration globale non trouvé. Exécutez 'devkit config init' pour en créer un."
+          "found": "Fichier de configuration globale non trouvé. Exécutez 'devkit config init --global' pour en créer un."
         }
       },
       "local": {
         "not": {
-          "found": "Aucun fichier de configuration locale trouvé."
+          "found": "Aucun fichier de configuration locale trouvé. Exécutez 'devkit config init --local' pour en créer un."
         }
       },
       "generic": "Erreur de configuration",
       "init": {
-        "fail": "Échec de l'initialisation de la configuration."
+        "fail": "Échec de l'initialisation de la configuration.",
+        "local_and_global": "Impossible d'utiliser les deux options --local et --global en même temps."
       },
       "read": "Échec de la lecture de la configuration à {path}.",
       "no_file_found": "Aucun fichier de configuration trouvé. Exécutez 'devkit config init' pour en créer un global, ou 'devkit config init --local' pour en créer un local.",
@@ -198,28 +219,28 @@
       "failed_to_update_project_name": "Échec de la mise à jour du nom du projet :"
     },
     "version": {
-      "read_fail": "Échec de la lecture de la version de package.json."
+      "read_fail": "Échec de la lecture de la version dans package.json."
     },
     "template": {
-      "not_found": "Modèle '{template}' non trouvé dans la configuration.",
-      "exists": "Le modèle '{template}' existe déjà dans la configuration. Utilisez 'devkit config set' pour le mettre à jour."
+      "not_found": "Template '{template}' non trouvé dans la configuration.",
+      "exists": "Le template '{template}' existe déjà dans la configuration. Utilisez 'devkit config set' pour le mettre à jour."
     },
     "alias": {
-      "exists": "L'alias '{alias}' existe déjà pour un autre modèle dans ce langage. Veuillez choisir un alias différent."
+      "exists": "L'alias '{alias}' existe déjà pour un autre template dans ce langage. Veuillez choisir un alias différent."
     },
     "install": {
       "message": "Erreur d'installation :"
     },
     "scaffolding": {
-      "unexpected": "Une erreur inattendue est survenue lors de la création du projet.",
+      "unexpected": "Une erreur inattendue est survenue pendant le scaffolding.",
       "language": {
-        "not_found": "Langage de création non trouvé dans la configuration : '{language}'"
+        "not_found": "Langage de scaffolding non trouvé dans la configuration : '{language}'"
       }
     },
     "command": {
       "config": {
         "cache": {
-          "fail": "Échec de la mise à jour de la stratégie de cache pour le modèle '{template}'"
+          "fail": "Échec de la mise à jour de la stratégie de cache pour le template '{template}'"
         }
       }
     },
@@ -235,24 +256,24 @@
     },
     "unexpected": "Une erreur inattendue est survenue",
     "unknown": "Une erreur inconnue est survenue",
-    "language_config_not_found": "Langage de configuration non trouvé : '{language}'"
+    "language_config_not_found": "Langage de scaffolding non trouvé dans la configuration : '{language}'"
   },
   "cache": {
     "clone": {
-      "start": "✨ Clonage du nouveau modèle depuis {url}...",
-      "success": "✅ Modèle cloné avec succès !",
+      "start": "✨ Clonage du nouveau template depuis {url}...",
+      "success": "✅ Template cloné avec succès !",
       "fail": "❌ Échec du clonage du dépôt."
     },
     "refresh": {
-      "start": "🔄 Rafraîchissement du modèle en cache...",
-      "success": "✅ Modèle rafraîchi avec succès !",
-      "fail": "❌ Échec du rafraîchissement du modèle."
+      "start": "🔄 Rafraîchissement du template en cache...",
+      "success": "✅ Template rafraîchi avec succès !",
+      "fail": "❌ Échec du rafraîchissement du template."
     },
     "use": {
-      "info": "🚀 Utilisation du modèle en cache pour {repoName}."
+      "info": "🚀 Utilisation du template en cache pour {repoName}."
     },
     "copy": {
-      "start": "📂 Copie du modèle en cache vers le répertoire du projet...",
+      "start": "📂 Copie du template en cache vers le répertoire du projet...",
       "success": "✅ Fichiers copiés avec succès !",
       "fail": "❌ Échec de la copie des fichiers depuis le cache."
     }
@@ -260,7 +281,7 @@
   "warning": {
     "no": {
       "local": {
-        "config": "Aucun fichier de configuration de projet local trouvé. Utilisation des paramètres globaux ou par défaut."
+        "config": "Aucune configuration de projet locale trouvée. Utilisation des paramètres globaux ou par défaut."
       }
     },
     "global": {
@@ -274,15 +295,15 @@
   },
   "cli": {
     "add_template": {
-      "description": "Ajouter un nouveau modèle à la configuration",
+      "description": "Ajouter un nouveau template à la configuration",
       "options": {
-        "description": "Une brève description du modèle",
-        "alias": "Un alias court pour le modèle",
-        "cache": "La stratégie de cache pour le modèle",
-        "package_manager": "Le gestionnaire de paquets à utiliser pour le modèle"
+        "description": "Une brève description du template",
+        "alias": "Un alias court pour le template",
+        "cache": "La stratégie de cache pour le template",
+        "package_manager": "Le gestionnaire de paquets à utiliser pour le template"
       },
-      "adding": "Ajout du modèle '{templateName}' à la configuration...",
-      "success": "Modèle '{templateName}' ajouté avec succès !"
+      "adding": "Ajout du template '{templateName}' à la configuration...",
+      "success": "Template '{templateName}' ajouté avec succès !"
     }
   }
 }

--- a/packages/devkit/src/commands/config/index.ts
+++ b/packages/devkit/src/commands/config/index.ts
@@ -1,0 +1,15 @@
+import { type SetupCommandOptions } from "#utils/configs/schema.js";
+import { t } from "#utils/internationalization/i18n.js";
+import { setupConfigSetCommand } from "./set.js";
+import { setupConfigUpdateCommand } from "./update.js";
+
+export function setupConfigCommand(options: SetupCommandOptions) {
+  const { program, config, source } = options;
+  const configCommand = program
+    .command("config")
+    .alias("cf")
+    .description(t("config.command.description"));
+
+  setupConfigSetCommand({ program: configCommand, config, source });
+  setupConfigUpdateCommand({ program: configCommand, config, source });
+}

--- a/packages/devkit/src/commands/config/update.ts
+++ b/packages/devkit/src/commands/config/update.ts
@@ -1,0 +1,247 @@
+import {
+  saveLocalConfig,
+  saveGlobalConfig,
+  readConfigAtPath,
+  getConfigFilepath,
+} from "#utils/configs/loader.js";
+import {
+  VALID_CACHE_STRATEGIES,
+  VALID_PACKAGE_MANAGERS,
+  type CliConfig,
+  type TemplateConfig,
+  type SetupCommandOptions,
+  type UpdateCommandOptions,
+} from "#utils/configs/schema.js";
+import { t } from "#utils/internationalization/i18n.js";
+import { DevkitError } from "#utils/errors/base.js";
+import { handleErrorAndExit } from "#utils/errors/handler.js";
+import ora from "ora";
+import chalk from "chalk";
+import deepmerge from "deepmerge";
+
+async function getTargetConfig(
+  isGlobal: boolean,
+  source: string,
+  config: CliConfig,
+): Promise<CliConfig> {
+  if (!source || source === "default") {
+    throw new DevkitError(t("error.config.no_file_found"));
+  }
+
+  if (isGlobal) {
+    if (source === "global") {
+      return deepmerge({}, config);
+    } else {
+      const globalConfigPath = await getConfigFilepath(true);
+      const globalConfig = await readConfigAtPath(globalConfigPath);
+      if (!globalConfig) {
+        throw new DevkitError(t("error.config.global.not.found"));
+      }
+      return deepmerge({}, globalConfig);
+    }
+  } else {
+    if (source !== "local") {
+      throw new DevkitError(t("error.config.local.not.found"));
+    }
+    return deepmerge({}, config);
+  }
+}
+
+function getTemplateConfig(
+  targetConfig: CliConfig,
+  language: string,
+  templateName: string,
+): { key: string; config: TemplateConfig } {
+  const languageTemplates = targetConfig.templates[language];
+  if (!languageTemplates) {
+    throw new DevkitError(t("error.language_config_not_found", { language }));
+  }
+
+  const templateKey = Object.keys(languageTemplates.templates).find(
+    (key) =>
+      key === templateName ||
+      languageTemplates.templates[key]?.alias === templateName,
+  );
+
+  if (!templateKey) {
+    throw new DevkitError(
+      t("error.template.not_found", { template: templateName }),
+    );
+  }
+
+  const templateConfig = languageTemplates.templates[templateKey];
+  if (!templateConfig) {
+    throw new DevkitError(
+      t("error.template.not_found", { template: templateName }),
+    );
+  }
+
+  return { key: templateKey, config: templateConfig };
+}
+
+function processUpdates(cmdOptions: UpdateCommandOptions): {
+  updates: any;
+  deletions: string[];
+} {
+  const { description, alias, location, cacheStrategy, packageManager } =
+    cmdOptions;
+  const updates: any = {};
+  const deletions: string[] = [];
+
+  if (description !== undefined) {
+    if (description === "null") {
+      throw new DevkitError(
+        t("error.invalid.remove_required", { key: "description" }),
+      );
+    }
+    updates.description = description;
+  }
+
+  if (location !== undefined) {
+    if (location === "null") {
+      throw new DevkitError(
+        t("error.invalid.remove_required", { key: "location" }),
+      );
+    }
+    updates.location = location;
+  }
+
+  if (alias !== undefined) {
+    if (alias === "null") {
+      deletions.push("alias");
+    } else {
+      updates.alias = alias;
+    }
+  }
+
+  if (cacheStrategy !== undefined) {
+    if (cacheStrategy === "null") {
+      deletions.push("cacheStrategy");
+    } else if (!VALID_CACHE_STRATEGIES.includes(cacheStrategy)) {
+      throw new DevkitError(
+        t("error.invalid.cache_strategy", {
+          value: cacheStrategy,
+          options: VALID_CACHE_STRATEGIES.join(", "),
+        }),
+      );
+    } else {
+      updates.cacheStrategy = cacheStrategy;
+    }
+  }
+
+  if (packageManager !== undefined) {
+    if (packageManager === "null") {
+      deletions.push("packageManager");
+    } else if (!VALID_PACKAGE_MANAGERS.includes(packageManager)) {
+      throw new DevkitError(
+        t("error.invalid.package_manager", {
+          value: packageManager,
+          options: VALID_PACKAGE_MANAGERS.join(", "),
+        }),
+      );
+    } else {
+      updates.packageManager = packageManager;
+    }
+  }
+
+  return { updates, deletions };
+}
+
+async function saveConfig(
+  targetConfig: CliConfig,
+  isGlobal: boolean,
+): Promise<void> {
+  if (isGlobal) {
+    await saveGlobalConfig(targetConfig);
+  } else {
+    await saveLocalConfig(targetConfig);
+  }
+}
+
+export function setupConfigUpdateCommand(options: SetupCommandOptions) {
+  const { program, config, source } = options;
+
+  program
+    .command("update")
+    .alias("up")
+    .description(t("config.update.command.description"))
+    .argument("<language>", t("config.update.language.argument"))
+    .argument("<templateName>", t("config.update.template.argument"))
+    .option("-n, --new-name <string>", t("config.update.option.new_name"))
+    .option("-d, --description <string>", t("config.update.option.description"))
+    .option("-a, --alias <string>", t("config.update.option.alias"))
+    .option("-l, --location <string>", t("config.update.option.location"))
+    .option(
+      "--cache-strategy <string>",
+      t("config.update.option.cache_strategy"),
+    )
+    .option(
+      "--package-manager <string>",
+      t("config.update.option.package_manager"),
+    )
+    .option("-g, --global", t("config.update.option.global"), false)
+    .action(
+      async (
+        language: string,
+        templateName: string,
+        cmdOptions: UpdateCommandOptions,
+      ) => {
+        const spinner = ora(
+          chalk.cyan(t("config.update.updating", { templateName })),
+        ).start();
+
+        try {
+          const { global: isGlobal, newName } = cmdOptions;
+          const targetConfig = await getTargetConfig(
+            isGlobal,
+            source as string,
+            config,
+          );
+          const { key: templateKey, config: templateConfig } =
+            getTemplateConfig(targetConfig, language, templateName);
+          const { updates, deletions } = processUpdates(cmdOptions);
+
+          const mergedTemplate = deepmerge(templateConfig, updates);
+
+          const finalTemplate = Object.fromEntries(
+            Object.entries(mergedTemplate).filter(
+              ([key]) => !deletions.includes(key),
+            ),
+          ) as TemplateConfig;
+
+          const updatedLanguageTemplates = Object.fromEntries(
+            Object.entries(targetConfig.templates[language]!.templates).filter(
+              ([key]) => key !== templateKey,
+            ),
+          );
+
+          if (newName && newName !== templateKey) {
+            if (targetConfig.templates[language]!.templates[newName]) {
+              throw new DevkitError(
+                t("error.template.exists", { template: newName }),
+              );
+            }
+            updatedLanguageTemplates[newName] = finalTemplate;
+          } else {
+            updatedLanguageTemplates[templateKey] = finalTemplate;
+          }
+
+          targetConfig.templates[language]!.templates =
+            updatedLanguageTemplates;
+
+          await saveConfig(targetConfig, isGlobal);
+
+          const successMessage = newName
+            ? t("config.update.success_name", {
+                oldName: templateName,
+                newName,
+              })
+            : t("config.update.success", { templateName });
+
+          spinner.succeed(chalk.italic.green(successMessage));
+        } catch (error) {
+          handleErrorAndExit(error, spinner);
+        }
+      },
+    );
+}

--- a/packages/devkit/src/commands/init.ts
+++ b/packages/devkit/src/commands/init.ts
@@ -1,0 +1,60 @@
+import { saveLocalConfig, saveGlobalConfig } from "#utils/configs/loader.js";
+import {
+  CONFIG_FILE_NAMES,
+  defaultCliConfig,
+  type SetupCommandOptions,
+} from "#utils/configs/schema.js";
+import { t } from "#utils/internationalization/i18n.js";
+import { ConfigError } from "#utils/errors/base.js";
+import fs from "fs-extra";
+import path from "path";
+import os from "os";
+import ora from "ora";
+import chalk from "chalk";
+
+export function setupInitCommand(options: SetupCommandOptions) {
+  const { program } = options;
+  program
+    .command("init")
+    .alias("i")
+    .description(t("config.init.command.description"))
+    .option("-l, --local", t("config.init.option.local"), false)
+    .option("-g, --global", t("config.init.option.global"), false)
+    .action(async (cmdOptions) => {
+      const isLocal = cmdOptions.local;
+      const isGlobal = cmdOptions.global;
+
+      if (isLocal && isGlobal) {
+        throw new ConfigError(t("error.config.init.local_and_global"));
+      }
+
+      const configPath = isLocal
+        ? path.join(process.cwd(), CONFIG_FILE_NAMES[1])
+        : path.join(os.homedir(), CONFIG_FILE_NAMES[0]);
+
+      const spinner = ora(
+        chalk.cyan(t("config.init.initializing", { path: configPath })),
+      ).start();
+
+      try {
+        await fs.promises.stat(configPath);
+        throw new ConfigError(
+          t("error.config.exists", { path: configPath }),
+          configPath,
+        );
+      } catch (error: any) {
+        if (error.code !== "ENOENT") {
+          throw new ConfigError(t("error.config.init.fail"), configPath, {
+            cause: error,
+          });
+        }
+      }
+
+      if (isLocal) {
+        await saveLocalConfig({ ...defaultCliConfig });
+      } else {
+        await saveGlobalConfig({ ...defaultCliConfig });
+      }
+      spinner.succeed(chalk.green(t("config.init.success")));
+    });
+}

--- a/packages/devkit/src/index.ts
+++ b/packages/devkit/src/index.ts
@@ -12,9 +12,11 @@ import chalk from "chalk";
 import { getProjectVersion } from "#utils/project.js";
 import { handleErrorAndExit } from "#utils/errors/handler.js";
 import { setupNewCommand } from "./commands/new.js";
-import { setupConfigCommand } from "./commands/config.js";
+import { setupConfigCommand } from "./commands/config/index.js";
 import { setupListCommand } from "./commands/list.js";
 import { setupRemoveTemplateCommand } from "./commands/removeTemplate.js";
+import { setupAddTemplateCommand } from "./commands/add-template.js";
+import { setupInitCommand } from "./commands/init.js";
 
 const VERSION = await getProjectVersion();
 
@@ -47,10 +49,12 @@ async function setupAndParse() {
       .helpOption("-h, --help", t("help.description"));
 
     const commandOptions = { program, config, configPath, source };
+    setupInitCommand({ program, config });
     setupNewCommand({ program, config });
     setupConfigCommand({ program, config, source });
     setupListCommand({ program, config });
     setupRemoveTemplateCommand(commandOptions);
+    setupAddTemplateCommand({ program, config, source });
 
     program.parse();
   } catch (error) {

--- a/packages/devkit/src/utils/configs/schema.ts
+++ b/packages/devkit/src/utils/configs/schema.ts
@@ -68,11 +68,7 @@ export interface LanguageConfig {
 }
 
 export interface CliConfig {
-  templates: {
-    [key in SupportedProgrammingLanguageValues]?: LanguageConfig;
-  } & {
-    [key: string]: LanguageConfig;
-  };
+  templates: Record<string, LanguageConfig>;
   settings: {
     defaultPackageManager: SupportedPackageManager;
     cacheStrategy?: CacheStrategy;
@@ -81,6 +77,16 @@ export interface CliConfig {
 }
 
 export type ConfigurationSource = "local" | "global" | "default";
+
+export interface UpdateCommandOptions {
+  global: boolean;
+  description?: string;
+  alias?: string;
+  location?: string;
+  cacheStrategy?: CacheStrategy | "null";
+  packageManager?: SupportedPackageManager | "null";
+  newName?: string;
+}
 
 export interface SetupCommandOptions {
   program: Command;


### PR DESCRIPTION
## Description

This PR introduces a new `config update` command, a feature that allows users to modify existing template configurations directly from the command line. This command can be used to update a template's properties, such as its `description`, `alias`, `location`, `cache-strategy`, and `package-manager`.

The main addition is the `--new-name` option, which enables users to rename a template, providing a convenient way to correct typos or change a template's identifier.

This change improves the overall user experience by centralizing template management and reducing the need for manual file editing, which can lead to syntax errors.

Fixes # N/A (This is a new feature)

***

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

***

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules