### PR TITLE
feat: support the setting of many configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You must provide a `description` using the `--description` flag. Other options l
 
 ```bash
 # Example: Add a new template from a GitHub repository
-dk add-template javascript react-ts-template https://github.com/my-user/my-react-ts-template --description "My custom React TS template"
+dk add-template javascript react-ts-template [https://github.com/my-user/my-react-ts-template](https://github.com/my-user/my-react-ts-template) --description "My custom React TS template"
 ```
 
 ### Update a template's configuration
@@ -158,14 +158,14 @@ dk list javascript
 
 ### Manage your CLI configuration
 
-Use the `config set` command to update your `.devkitrc` file.
+The `config set` command allows you to update one or more CLI settings in a single command.
 
 ```bash
-# Set your default package manager to pnpm
-dk config set pm pnpm
+# Set your default package manager to pnpm and the language to French in a single command
+dk config set pm pnpm language fr
 
-# Set the language to French
-dk config set language fr
+# Alternatively, you can set a single value
+dk config set pm npm
 ```
 
 ### Manage cache strategy for a template
@@ -254,7 +254,7 @@ For a better developer experience, add a `$schema` property for auto-completion 
 
 ```json
 {
-  "$schema": "https://www.shorturl.at/QDcxK",
+  "$schema": "[https://www.shorturl.at/QDcxK](https://www.shorturl.at/QDcxK)",
   "settings": {
     "language": "fr",
     "defaultPackageManager": "npm",
@@ -265,7 +265,7 @@ For a better developer experience, add a `$schema` property for auto-completion 
       "templates": {
         "react": {
           "description": "A robust React project with TypeScript",
-          "location": "https://github.com/IT-WIBRC/react-ts-template",
+          "location": "[https://github.com/IT-WIBRC/react-ts-template](https://github.com/IT-WIBRC/react-ts-template)",
           "alias": "rt"
         },
         "nextjs": {
@@ -296,7 +296,7 @@ You can also define an **`alias`** to make it easier to reference a specific tem
         },
         "from-github": {
           "description": "A template from a GitHub repository",
-          "location": "https://github.com/my-user/my-template-repo",
+          "location": "[https://github.com/my-user/my-template-repo](https://github.com/my-user/my-template-repo)",
           "alias": "gh-template",
           "cacheStrategy": "daily"
         },

--- a/TODO.md
+++ b/TODO.md
@@ -18,13 +18,13 @@ This document tracks all planned tasks, bugs, and future ideas for the Dev Kit p
 - [x] Detect system language dynamically
 - [x] Support Monorepo configuration
 - [x] Configure aliases
-- [ ] Find a way to test the templates
+- [ ] Add unit tests
 - [x] Refactor the `new` command to accept option to select a template
 - [x] Warn user to not use already used names for templates and tell we only support js templates containing nodejs related templates (No need anymore as user can create custom templates or edit existing ones)
 - [x] Add a command to list all available templates
 - [x] Add a command to remove a template
 - [x] Add a command to update a template (name and options)
-- [ ] Refactor the `set` command so support the setting of many config at once and also with possibility of
+- [x] Improve the `set` command so support the setting of many config at once
 - [ ] Improve the config management (Share config get on mounted and get it later only when necessary)
 - [ ] Add a command to update the CLI itself
 - [ ] Add integration tests in addition to unit tests (reproduce monorepo, multi repo and bare repository)

--- a/packages/devkit/locales/en.json
+++ b/packages/devkit/locales/en.json
@@ -91,13 +91,10 @@
     },
     "set": {
       "command": {
-        "description": "Set a configuration value. \n\nAvailable keys:\n  pm, packageManager      - Sets the default package manager to use for new projects.\n                          Possible values: {pmValues}\n  cache, cacheStrategy    - Sets the global caching behavior for remote templates.\n                          Possible values: 'always-refresh', 'never-refresh', 'daily'\n  language, lg            - Sets the language of the CLI. Possible values: 'en', 'fr'\n"
+        "description": "Set one or more configuration values. \n\nAvailable keys:\n  pm, packageManager      - Sets the default package manager to use for new projects.\n                          Possible values: {pmValues}\n  cache, cacheStrategy    - Sets the global caching behavior for remote templates.\n                          Possible values: 'always-refresh', 'never-refresh', 'daily'\n  language, lg            - Sets the language of the CLI. Possible values: 'en', 'fr'\n"
       },
-      "key": {
-        "argument": "The configuration key to set"
-      },
-      "value": {
-        "argument": "The new value for the key"
+      "argument": {
+        "description": "A list of key-value pairs to set (e.g., 'pm npm language fr')"
       },
       "option": {
         "global": "Update the global configuration instead of the local one."
@@ -242,6 +239,9 @@
         "cache": {
           "fail": "Failed to update cache strategy for template '{template}'"
         }
+      },
+      "set": {
+        "invalid_arguments_count": "Invalid number of arguments. Please provide key-value pairs."
       }
     },
     "save": {

--- a/packages/devkit/locales/fr.json
+++ b/packages/devkit/locales/fr.json
@@ -91,13 +91,10 @@
     },
     "set": {
       "command": {
-        "description": "Définir une valeur de configuration. \n\nClés disponibles :\n  pm, packageManager      - Définit le gestionnaire de paquets par défaut à utiliser pour les nouveaux projets.\n                          Valeurs possibles : {pmValues}\n  cache, cacheStrategy    - Définit le comportement de mise en cache globale pour les templates distants.\n                          Valeurs possibles : 'always-refresh', 'never-refresh', 'daily'\n  language, lg            - Définit le langage de la CLI. Valeurs possibles : 'en', 'fr'\n"
+        "description": "Définir une ou plusieurs valeurs de configuration. \n\nClés disponibles :\n  pm, packageManager      - Définit le gestionnaire de paquets par défaut à utiliser pour les nouveaux projets.\n                          Valeurs possibles : {pmValues}\n  cache, cacheStrategy    - Définit le comportement de mise en cache globale pour les templates distants.\n                          Valeurs possibles : 'always-refresh', 'never-refresh', 'daily'\n  language, lg            - Définit le langage de la CLI. Valeurs possibles : 'en', 'fr'\n"
       },
-      "key": {
-        "argument": "La clé de configuration à définir"
-      },
-      "value": {
-        "argument": "La nouvelle valeur pour la clé"
+      "argument": {
+        "description": "Une liste de paires clé-valeur à définir (par exemple, 'pm npm lg fr')"
       },
       "option": {
         "global": "Mettre à jour la configuration globale au lieu de la configuration locale."
@@ -242,6 +239,9 @@
         "cache": {
           "fail": "Échec de la mise à jour de la stratégie de cache pour le template '{template}'"
         }
+      },
+      "set": {
+        "invalid_arguments_count": "Nombre d'arguments invalide. Veuillez fournir des paires clé-valeur."
       }
     },
     "save": {

--- a/packages/devkit/src/utils/configs/schema.ts
+++ b/packages/devkit/src/utils/configs/schema.ts
@@ -71,7 +71,7 @@ export interface CliConfig {
   templates: Record<string, LanguageConfig>;
   settings: {
     defaultPackageManager: SupportedPackageManager;
-    cacheStrategy?: CacheStrategy;
+    cacheStrategy: CacheStrategy;
     language: TextLanguageValues;
   };
 }


### PR DESCRIPTION
## Description

This pull request introduces a major improvement to the `config set` command. The command has been updated to accept a variadic number of arguments, allowing users to update multiple configuration settings at once. This change enhances the CLI's efficiency and user experience by eliminating the need to run separate commands for each setting.

For example, users can now set both their default package manager and their preferred language in a single command: `dk config set pm npm lg fr`. This new flexibility streamlines the initial setup process and general configuration management.

Fixes # N/A (New feature)

***

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

***

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules