### PR TITLE
feat: add commands to get settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ dk list --all
 
 ### Manage your CLI configuration
 
+#### Set a configuration value
+
 The `config set` command allows you to update one or more CLI settings in a single command.
 
 ```bash
@@ -196,6 +198,21 @@ dk config set pm pnpm language fr
 
 # Alternatively, you can set a single value
 dk config set pm npm
+```
+
+#### Get a configuration value
+
+The `config get` command allows you to view the current value of a configuration setting. If no key is specified, it will show the entire configuration file.
+
+```bash
+# Get the value of the 'defaultPackageManager' setting
+dk config get pm
+
+# Get the value of the 'language' setting from the global config
+dk config get language --global
+
+# Display the entire local configuration file
+dk config get
 ```
 
 ### Manage cache strategy for a template
@@ -263,7 +280,7 @@ dk new javascript my-awesome-project -t custom-js-app
 
 ### Create and configure a project file
 
-The `config init` command allows you to initialize a configuration file at different scopes.
+The `init` command allows you to initialize a configuration file at different scopes.
 
 **Note:** If a configuration file already exists at the specified location, you will be prompted to confirm if you want to overwrite it.
 
@@ -274,13 +291,13 @@ The `config init` command allows you to initialize a configuration file at diffe
 
 ```bash
 # Initialize a local configuration file in the current directory (default)
-dk config init
+dk init
 
 # Initialize a local configuration file in the current directory (explicit)
-dk config init --local
+dk init --local
 
 # Initialize a global configuration file
-dk config init --global
+dk init --global
 ```
 
 ### Add the JSON Schema for Autocompletion

--- a/TODO.md
+++ b/TODO.md
@@ -54,10 +54,9 @@ This document tracks all planned and completed tasks for the Dev Kit project.
 
 - [x] Add integration tests (reproduce monorepo, multi-repo, and bare repositories).
 - [x] change config file for local project from `.devkitrc.json` to `.devkit.json`
-- [ ] Add commands to get settings (e.g., `config get <key>`).
+- [x] Add commands to get settings (e.g., `config get <key>`).
+- [ ] Refactor the `findGlobalConfig` function
 - [ ] Add templates for popular Node.js frameworks (e.g., Express, Next.js, NestJS).
 - [ ] Use Changesets for changelog and versioning.
 - [ ] **Multi-Programming Language Support**: Progressively add templates for other languages (e.g., Python, Ruby, Go, Rust).
 - [ ] **Advanced Documentation**: Create detailed guides on creating and managing custom templates.
-- [ ] (Maybe) Support environment variables.
-- [ ] (Maybe) Add a command to update the CLI itself.

--- a/packages/devkit/__tests__/integrations/configs.spec.ts
+++ b/packages/devkit/__tests__/integrations/configs.spec.ts
@@ -23,7 +23,7 @@ const GLOBAL_CONFIG_FILE_NAME = CONFIG_FILE_NAMES[0];
 let tempDir: string;
 let originalCwd: string;
 
-describe("dk config set", () => {
+describe("dk config commands", () => {
   beforeAll(() => {
     vi.unmock("execa");
   });
@@ -45,104 +45,259 @@ describe("dk config set", () => {
     await fs.remove(tempDir);
   });
 
-  it("should set a single config value in settings correctly", async () => {
-    const { all, exitCode } = await execa(
-      "bun",
-      [CLI_PATH, "config", "set", "pm", "bun"],
-      { all: true },
-    );
+  describe("dk config set", () => {
+    it("should set a single config value in settings correctly", async () => {
+      const { all, exitCode } = await execa(
+        "bun",
+        [CLI_PATH, "config", "set", "pm", "bun"],
+        { all: true },
+      );
 
-    expect(exitCode).toBe(0);
-    expect(all).toContain("✔ Configuration updated successfully!");
+      expect(exitCode).toBe(0);
+      expect(all).toContain("✔ Configuration updated successfully!");
 
-    const configContent = await fs.readJson(
-      path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
-    );
-    expect(configContent.settings.defaultPackageManager).toBe("bun");
+      const configContent = await fs.readJson(
+        path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
+      );
+      expect(configContent.settings.defaultPackageManager).toBe("bun");
+    });
+
+    it("should set multiple config values in settings correctly", async () => {
+      const { all, exitCode } = await execa(
+        "bun",
+        [CLI_PATH, "config", "set", "pm", "yarn", "language", "fr"],
+        { all: true },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(all).toContain("✔ Configuration updated successfully!");
+
+      const configContent = await fs.readJson(
+        path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
+      );
+      expect(configContent.settings.defaultPackageManager).toBe("yarn");
+      expect(configContent.settings.language).toBe("fr");
+    });
+
+    it("should update a global config file when --global flag is used", async () => {
+      const tempGlobalHome = path.join(
+        os.tmpdir(),
+        `global-home-${Date.now()}`,
+      );
+      await fs.ensureDir(tempGlobalHome);
+      const globalConfigPath = path.join(
+        tempGlobalHome,
+        GLOBAL_CONFIG_FILE_NAME,
+      );
+      await fs.writeJson(globalConfigPath, defaultCliConfig, { spaces: 2 });
+
+      const { all, exitCode } = await execa(
+        "bun",
+        [CLI_PATH, "config", "set", "language", "fr", "--global"],
+        { all: true, env: { HOME: tempGlobalHome } },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(all).toContain("✔ Configuration updated successfully!");
+
+      const globalConfigContent = await fs.readJson(globalConfigPath);
+      expect(globalConfigContent.settings.language).toBe("fr");
+
+      await fs.remove(tempGlobalHome);
+    });
+
+    it("should show an error for an invalid key", async () => {
+      const { all, exitCode } = await execa(
+        "bun",
+        [CLI_PATH, "config", "set", "invalid_key", "value"],
+        { all: true, reject: false },
+      );
+
+      expect(exitCode).not.toBe(0);
+      expect(all).toContain(
+        "An unexpected error occurred: Invalid key: 'invalid_key'. Valid keys are: pm, packageManager, cache, cacheStrategy, language, lg",
+      );
+      const configContent = await fs.readJson(
+        path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
+      );
+      expect(configContent).toEqual(defaultCliConfig);
+    });
+
+    it("should show an error for an invalid value", async () => {
+      const { all, exitCode } = await execa(
+        "bun",
+        [CLI_PATH, "config", "set", "language", "de"],
+        { all: true, reject: false },
+      );
+
+      expect(exitCode).not.toBe(0);
+      expect(all).toContain(
+        "An unexpected error occurred: Invalid value for language. Valid options are: en, fr",
+      );
+      const configContent = await fs.readJson(
+        path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
+      );
+      expect(configContent).toEqual(defaultCliConfig);
+    });
+
+    it("should show an error for a non-existent config file", async () => {
+      await fs.remove(path.join(tempDir, LOCAL_CONFIG_FILE_NAME));
+
+      const { all, exitCode } = await execa(
+        "bun",
+        [CLI_PATH, "config", "set", "pm", "bun"],
+        { all: true, reject: false },
+      );
+
+      expect(exitCode).not.toBe(0);
+      expect(all).toContain("No configuration file found.");
+    });
   });
 
-  it("should set multiple config values in settings correctly", async () => {
-    const { all, exitCode } = await execa(
-      "bun",
-      [CLI_PATH, "config", "set", "pm", "yarn", "language", "fr"],
-      { all: true },
-    );
+  describe("dk config get", () => {
+    it("should get a single value from the local config", async () => {
+      const { all, exitCode } = await execa(
+        "bun",
+        [CLI_PATH, "config", "get", "language"],
+        { all: true },
+      );
 
-    expect(exitCode).toBe(0);
-    expect(all).toContain("✔ Configuration updated successfully!");
+      expect(exitCode).toBe(0);
+      expect(all).toContain("✔ Configuration loaded successfully!");
+      expect(all).toContain("Using local configuration.");
+      expect(all).toContain("language: en");
+    });
 
-    const configContent = await fs.readJson(
-      path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
-    );
-    expect(configContent.settings.defaultPackageManager).toBe("yarn");
-    expect(configContent.settings.language).toBe("fr");
-  });
+    it("should get a value using an alias", async () => {
+      const { all, exitCode } = await execa(
+        "bun",
+        [CLI_PATH, "config", "get", "pm"],
+        { all: true },
+      );
 
-  it("should update a global config file when --global flag is used", async () => {
-    const homedir = os.homedir();
-    const globalConfigPath = path.join(homedir, GLOBAL_CONFIG_FILE_NAME);
-    await fs.writeJson(globalConfigPath, defaultCliConfig, { spaces: 2 });
+      expect(exitCode).toBe(0);
+      expect(all).toContain("✔ Configuration loaded successfully!");
+      expect(all).toContain("defaultPackageManager: bun");
+    });
 
-    const { all, exitCode } = await execa(
-      "bun",
-      [CLI_PATH, "config", "set", "language", "fr", "--global"],
-      { all: true },
-    );
+    it("should show an error for a non-existent key", async () => {
+      const { all, exitCode } = await execa(
+        "bun",
+        [CLI_PATH, "config", "get", "invalid-key"],
+        { all: true, reject: false },
+      );
 
-    expect(exitCode).toBe(0);
-    expect(all).toContain("✔ Configuration updated successfully!");
+      expect(exitCode).toBe(0);
+      expect(all).toContain("Configuration key 'invalid-key' not found.");
+    });
 
-    const globalConfigContent = await fs.readJson(globalConfigPath);
-    expect(globalConfigContent.settings.language).toBe("fr");
+    it("should get the entire local config if no key is specified", async () => {
+      const { all, exitCode } = await execa(
+        "bun",
+        [CLI_PATH, "config", "get"],
+        {
+          all: true,
+        },
+      );
 
-    // Clean up
-    await fs.remove(globalConfigPath);
-  });
+      expect(exitCode).toBe(0);
+      expect(all).toContain("✔ Configuration loaded successfully!");
+      expect(all).toContain("Using local configuration.");
+      expect(all).toContain('"language": "en"');
+      expect(all).toContain('"defaultPackageManager": "bun"');
+    });
 
-  it("should show an error for an invalid key", async () => {
-    const { all, exitCode } = await execa(
-      "bun",
-      [CLI_PATH, "config", "set", "invalid_key", "value"],
-      { all: true, reject: false },
-    );
+    it("should get a value from the global config when --global is used", async () => {
+      const tempGlobalHome = path.join(
+        os.tmpdir(),
+        `global-home-${Date.now()}`,
+      );
+      await fs.ensureDir(tempGlobalHome);
+      const globalConfigPath = path.join(
+        tempGlobalHome,
+        GLOBAL_CONFIG_FILE_NAME,
+      );
+      await fs.writeJson(
+        globalConfigPath,
+        {
+          ...defaultCliConfig,
+          settings: { ...defaultCliConfig.settings, language: "fr" },
+        },
+        { spaces: 2 },
+      );
 
-    expect(exitCode).not.toBe(0);
-    expect(all).toContain(
-      "An unexpected error occurred: Invalid key: 'invalid_key'. Valid keys are: pm, packageManager, cache, cacheStrategy, language, lg",
-    );
-    const configContent = await fs.readJson(
-      path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
-    );
-    expect(configContent).toEqual(defaultCliConfig); // No changes made
-  });
+      const { all, exitCode } = await execa(
+        "bun",
+        [CLI_PATH, "config", "get", "language", "--global"],
+        { all: true, env: { HOME: tempGlobalHome } },
+      );
 
-  it("should show an error for an invalid value", async () => {
-    const { all, exitCode } = await execa(
-      "bun",
-      [CLI_PATH, "config", "set", "language", "de"],
-      { all: true, reject: false },
-    );
+      expect(exitCode).toBe(0);
+      expect(all).toContain("✔ Configuration loaded successfully!");
+      expect(all).toContain("Using global configuration.");
+      expect(all).toContain("language: fr");
 
-    expect(exitCode).not.toBe(0);
-    expect(all).toContain(
-      "An unexpected error occurred: Invalid value for language. Valid options are: en, fr",
-    );
-    const configContent = await fs.readJson(
-      path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
-    );
-    expect(configContent).toEqual(defaultCliConfig); // No changes made
-  });
+      await fs.remove(tempGlobalHome);
+    });
 
-  it("should show an error for a non-existent config file", async () => {
-    await fs.remove(path.join(tempDir, LOCAL_CONFIG_FILE_NAME));
+    it("should fallback to global config if local is not present", async () => {
+      await fs.remove(path.join(tempDir, LOCAL_CONFIG_FILE_NAME));
 
-    const { all, exitCode } = await execa(
-      "bun",
-      [CLI_PATH, "config", "set", "pm", "bun"],
-      { all: true, reject: false },
-    );
+      const tempGlobalHome = path.join(
+        os.tmpdir(),
+        `global-home-${Date.now()}`,
+      );
+      await fs.ensureDir(tempGlobalHome);
+      const globalConfigPath = path.join(
+        tempGlobalHome,
+        GLOBAL_CONFIG_FILE_NAME,
+      );
+      await fs.writeJson(globalConfigPath, {
+        ...defaultCliConfig,
+        settings: {
+          ...defaultCliConfig.settings,
+          defaultPackageManager: "yarn",
+        },
+      });
 
-    expect(exitCode).not.toBe(0);
-    expect(all).toContain("No configuration file found.");
+      const { all, exitCode } = await execa(
+        "bun",
+        [CLI_PATH, "config", "get", "pm"],
+        { all: true, env: { HOME: tempGlobalHome } },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(all).toContain("✔ Configuration loaded successfully!");
+      expect(all).toContain(
+        "No local configuration file found. Displaying global settings instead.",
+      );
+      expect(all).toContain("defaultPackageManager: yarn");
+
+      await fs.remove(tempGlobalHome);
+    });
+
+    it("should show default fallback message if no config files are found", async () => {
+      await fs.remove(path.join(tempDir, LOCAL_CONFIG_FILE_NAME));
+      const tempGlobalHome = path.join(
+        os.tmpdir(),
+        `global-home-${Date.now()}`,
+      );
+      await fs.ensureDir(tempGlobalHome);
+
+      const { all, exitCode } = await execa(
+        "bun",
+        [CLI_PATH, "config", "get", "language"],
+        { all: true, env: { HOME: tempGlobalHome } },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(all).toContain("✔ Configuration loaded successfully!");
+      expect(all).toContain(
+        "No local configuration file found. Displaying default settings instead.",
+      );
+      expect(all).toContain("language: en");
+
+      await fs.remove(tempGlobalHome);
+    });
   });
 });

--- a/packages/devkit/__tests__/units/commands/config/get.spec.ts
+++ b/packages/devkit/__tests__/units/commands/config/get.spec.ts
@@ -1,0 +1,230 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { setupConfigGetCommand } from "../../../../src/commands/config/get.js";
+import { mockSpinner, mockChalk } from "../../../../vitest.setup.js";
+import type { CliConfig } from "../../../../src/utils/configs/schema.js";
+
+const { mockHandleErrorAndExit, mockReadAndMergeConfigs } = vi.hoisted(() => ({
+  mockHandleErrorAndExit: vi.fn(),
+  mockReadAndMergeConfigs: vi.fn(),
+}));
+
+let actionFn: any;
+vi.mock("#utils/errors/handler.js", () => ({
+  handleErrorAndExit: mockHandleErrorAndExit,
+}));
+
+vi.mock("#utils/configs/loader.js", () => ({
+  readAndMergeConfigs: mockReadAndMergeConfigs,
+}));
+
+vi.mock("chalk", () => ({
+  default: {
+    cyan: vi.fn((message) => message),
+    bold: {
+      green: vi.fn((message) => message),
+      yellow: vi.fn((message) => message),
+    },
+    white: vi.fn((message) => message),
+    red: vi.fn((message) => message),
+  },
+}));
+
+describe("setupConfigGetCommand", () => {
+  let mockProgram: any;
+  const initialConfig: CliConfig = {
+    settings: {
+      defaultPackageManager: "npm",
+      cacheStrategy: "daily",
+      language: "en",
+    },
+    templates: {},
+  };
+
+  const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    actionFn = vi.fn();
+    mockProgram = {
+      command: vi.fn(() => mockProgram),
+      description: vi.fn(() => mockProgram),
+      argument: vi.fn(() => mockProgram),
+      option: vi.fn(() => mockProgram),
+      action: vi.fn((fn) => {
+        actionFn = fn;
+        return mockProgram;
+      }),
+    };
+
+    mockReadAndMergeConfigs.mockResolvedValue({
+      config: JSON.parse(JSON.stringify(initialConfig)),
+      source: "local",
+    });
+  });
+
+  it("should set up the config get command correctly", () => {
+    setupConfigGetCommand({
+      program: mockProgram,
+      config: initialConfig,
+      source: "local",
+    });
+    expect(mockProgram.command).toHaveBeenCalledWith("get");
+    expect(mockProgram.description).toHaveBeenCalledWith(
+      "config.get.command.description",
+    );
+    expect(mockProgram.argument).toHaveBeenCalledWith(
+      "[key]",
+      "config.get.argument.description",
+      "",
+    );
+    expect(mockProgram.option).toHaveBeenCalledWith(
+      "-g, --global",
+      "config.get.option.global",
+      false,
+    );
+  });
+
+  describe("get command action", () => {
+    it("should print the entire local config when no key is provided", async () => {
+      setupConfigGetCommand({
+        program: mockProgram,
+        config: initialConfig,
+        source: "local",
+      });
+      await actionFn("", {});
+      expect(mockSpinner.succeed).toHaveBeenCalledWith(
+        mockChalk.bold.green("config.get.success"),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        mockChalk.bold.yellow("config.get.source.local"),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        mockChalk.white(JSON.stringify(initialConfig.settings, null, 2)),
+      );
+      expect(mockHandleErrorAndExit).not.toHaveBeenCalled();
+    });
+
+    it("should print a specific value for a valid key", async () => {
+      setupConfigGetCommand({
+        program: mockProgram,
+        config: initialConfig,
+        source: "local",
+      });
+      await actionFn("language", {});
+      expect(mockSpinner.succeed).toHaveBeenCalledWith(
+        mockChalk.bold.green("config.get.success"),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        mockChalk.cyan("language:"),
+        mockChalk.white("en"),
+      );
+      expect(mockHandleErrorAndExit).not.toHaveBeenCalled();
+    });
+
+    it("should use the canonical key when an alias is provided", async () => {
+      setupConfigGetCommand({
+        program: mockProgram,
+        config: initialConfig,
+        source: "local",
+      });
+      await actionFn("pm", {});
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        mockChalk.cyan("defaultPackageManager:"),
+        mockChalk.white("npm"),
+      );
+    });
+
+    it("should print an error message for an invalid key", async () => {
+      setupConfigGetCommand({
+        program: mockProgram,
+        config: initialConfig,
+        source: "local",
+      });
+      await actionFn("invalid-key", {});
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        mockChalk.red("config.get.not_found- options key:invalid-key"),
+      );
+    });
+
+    it("should get from global config when --global flag is used", async () => {
+      mockReadAndMergeConfigs.mockResolvedValueOnce({
+        config: {
+          ...initialConfig,
+          settings: { ...initialConfig.settings, language: "fr" },
+        },
+        source: "global",
+      });
+      setupConfigGetCommand({
+        program: mockProgram,
+        config: initialConfig,
+        source: "local",
+      });
+      await actionFn("language", { global: true });
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        mockChalk.bold.yellow("config.get.source.global"),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        mockChalk.cyan("language:"),
+        mockChalk.white("fr"),
+      );
+    });
+
+    it("should handle local fallback to global config", async () => {
+      mockReadAndMergeConfigs.mockResolvedValueOnce({
+        config: {
+          ...initialConfig,
+          settings: { ...initialConfig.settings, language: "fr" },
+        },
+        source: "global",
+      });
+      setupConfigGetCommand({
+        program: mockProgram,
+        config: initialConfig,
+        source: "local",
+      });
+      await actionFn("language", { global: false });
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        mockChalk.bold.yellow("config.get.fallback.local_to_global"),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        mockChalk.cyan("language:"),
+        mockChalk.white("fr"),
+      );
+    });
+
+    it("should handle default fallback when --global is used and no config is found", async () => {
+      mockReadAndMergeConfigs.mockResolvedValueOnce({
+        config: initialConfig,
+        source: "default",
+      });
+      setupConfigGetCommand({
+        program: mockProgram,
+        config: initialConfig,
+        source: "local",
+      });
+      await actionFn("language", { global: true });
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        mockChalk.bold.yellow("config.get.fallback.global"),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        mockChalk.cyan("language:"),
+        mockChalk.white("en"),
+      );
+    });
+
+    it("should handle an error during the action", async () => {
+      const mockError = new Error("Config read failed");
+      mockReadAndMergeConfigs.mockRejectedValueOnce(mockError);
+      setupConfigGetCommand({
+        program: mockProgram,
+        config: initialConfig,
+        source: "local",
+      });
+      await actionFn("language", {});
+      expect(mockHandleErrorAndExit).toHaveBeenCalledWith(
+        mockError,
+        mockSpinner,
+      );
+    });
+  });
+});

--- a/packages/devkit/__tests__/units/commands/config/index.spec.ts
+++ b/packages/devkit/__tests__/units/commands/config/index.spec.ts
@@ -2,10 +2,10 @@ import { vi, describe, it, expect, beforeEach } from "vitest";
 import { setupConfigCommand } from "../../../../src/commands/config/index.js";
 import type { CliConfig } from "../../../../src/utils/configs/schema.js";
 
-const { mockSetupConfigSetCommand, mockSetupConfigUpdateCommand } = vi.hoisted(
+const { mockSetupConfigSetCommand, mockSetupConfigGetCommand } = vi.hoisted(
   () => ({
     mockSetupConfigSetCommand: vi.fn(),
-    mockSetupConfigUpdateCommand: vi.fn(),
+    mockSetupConfigGetCommand: vi.fn(),
   }),
 );
 
@@ -13,8 +13,8 @@ vi.mock("#commands/config/set.js", () => ({
   setupConfigSetCommand: mockSetupConfigSetCommand,
 }));
 
-vi.mock("#commands/config/update.js", () => ({
-  setupConfigUpdateCommand: mockSetupConfigUpdateCommand,
+vi.mock("#commands/config/get.js", () => ({
+  setupConfigGetCommand: mockSetupConfigGetCommand,
 }));
 
 describe("setupConfigCommand", () => {
@@ -72,5 +72,8 @@ describe("setupConfigCommand", () => {
     };
     expect(mockSetupConfigSetCommand).toHaveBeenCalledOnce();
     expect(mockSetupConfigSetCommand).toHaveBeenCalledWith(expectedOptions);
+
+    expect(mockSetupConfigGetCommand).toHaveBeenCalledOnce();
+    expect(mockSetupConfigGetCommand).toHaveBeenCalledWith(expectedOptions);
   });
 });

--- a/packages/devkit/__tests__/units/commands/config/set.spec.ts
+++ b/packages/devkit/__tests__/units/commands/config/set.spec.ts
@@ -9,12 +9,17 @@ import {
   TextLanguages,
 } from "../../../../src/utils/configs/schema.js";
 
-const { mockHandleErrorAndExit, mockSaveGlobalConfig, mockSaveLocalConfig } =
-  vi.hoisted(() => ({
-    mockHandleErrorAndExit: vi.fn(),
-    mockSaveGlobalConfig: vi.fn(),
-    mockSaveLocalConfig: vi.fn(),
-  }));
+const {
+  mockHandleErrorAndExit,
+  mockSaveGlobalConfig,
+  mockSaveLocalConfig,
+  mockReadAndMergeConfigs,
+} = vi.hoisted(() => ({
+  mockHandleErrorAndExit: vi.fn(),
+  mockSaveGlobalConfig: vi.fn(),
+  mockSaveLocalConfig: vi.fn(),
+  mockReadAndMergeConfigs: vi.fn(),
+}));
 
 let actionFn: any;
 vi.mock("#utils/errors/handler.js", () => ({
@@ -26,10 +31,12 @@ vi.mock("#utils/configs/writer", () => ({
   saveLocalConfig: mockSaveLocalConfig,
 }));
 
+vi.mock("#utils/configs/loader.js", () => ({
+  readAndMergeConfigs: mockReadAndMergeConfigs,
+}));
+
 describe("setupConfigSetCommand", () => {
   let mockProgram: any;
-  let config: CliConfig;
-
   const initialConfig: CliConfig = {
     settings: {
       defaultPackageManager: "npm",
@@ -41,7 +48,6 @@ describe("setupConfigSetCommand", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    config = JSON.parse(JSON.stringify(initialConfig));
     actionFn = vi.fn();
     mockProgram = {
       command: vi.fn(() => mockProgram),
@@ -53,12 +59,18 @@ describe("setupConfigSetCommand", () => {
         return mockProgram;
       }),
     };
+
+    // Set a default mock for readAndMergeConfigs
+    mockReadAndMergeConfigs.mockResolvedValue({
+      config: JSON.parse(JSON.stringify(initialConfig)),
+      source: "local",
+    });
   });
 
   it("should set up the config set command correctly", () => {
     setupConfigSetCommand({
       program: mockProgram,
-      config,
+      config: initialConfig,
       source: "local",
     });
     expect(mockProgram.command).toHaveBeenCalledWith("set");
@@ -79,13 +91,20 @@ describe("setupConfigSetCommand", () => {
   });
 
   it("should update a local config setting by key", async () => {
-    setupConfigSetCommand({ program: mockProgram, config, source: "local" });
+    setupConfigSetCommand({
+      program: mockProgram,
+      config: initialConfig,
+      source: "local",
+    });
     const settings = ["packageManager", "yarn"];
 
     await actionFn(settings, { global: false });
 
-    expect(config.settings.defaultPackageManager).toBe("yarn");
-    expect(mockSaveLocalConfig).toHaveBeenCalledWith(config);
+    const expectedConfig = {
+      ...initialConfig,
+      settings: { ...initialConfig.settings, defaultPackageManager: "yarn" },
+    };
+    expect(mockSaveLocalConfig).toHaveBeenCalledWith(expectedConfig);
     expect(mockSpinner.succeed).toHaveBeenCalledWith(
       mockChalk.bold.green(mocktFn("config.set.success")),
     );
@@ -93,13 +112,20 @@ describe("setupConfigSetCommand", () => {
   });
 
   it("should update a local config setting by alias", async () => {
-    setupConfigSetCommand({ program: mockProgram, config, source: "local" });
+    setupConfigSetCommand({
+      program: mockProgram,
+      config: initialConfig,
+      source: "local",
+    });
     const settings = ["pm", "bun"];
 
     await actionFn(settings, { global: false });
 
-    expect(config.settings.defaultPackageManager).toBe("bun");
-    expect(mockSaveLocalConfig).toHaveBeenCalledWith(config);
+    const expectedConfig = {
+      ...initialConfig,
+      settings: { ...initialConfig.settings, defaultPackageManager: "bun" },
+    };
+    expect(mockSaveLocalConfig).toHaveBeenCalledWith(expectedConfig);
     expect(mockSpinner.succeed).toHaveBeenCalledWith(
       mockChalk.bold.green(mocktFn("config.set.success")),
     );
@@ -107,14 +133,24 @@ describe("setupConfigSetCommand", () => {
   });
 
   it("should update multiple local config settings at once", async () => {
-    setupConfigSetCommand({ program: mockProgram, config, source: "local" });
+    setupConfigSetCommand({
+      program: mockProgram,
+      config: initialConfig,
+      source: "local",
+    });
     const settings = ["cacheStrategy", "never-refresh", "language", "fr"];
 
     await actionFn(settings, { global: false });
 
-    expect(config.settings.cacheStrategy).toBe("never-refresh");
-    expect(config.settings.language).toBe("fr");
-    expect(mockSaveLocalConfig).toHaveBeenCalledWith(config);
+    const expectedConfig = {
+      ...initialConfig,
+      settings: {
+        ...initialConfig.settings,
+        cacheStrategy: "never-refresh",
+        language: "fr",
+      },
+    };
+    expect(mockSaveLocalConfig).toHaveBeenCalledWith(expectedConfig);
     expect(mockSpinner.succeed).toHaveBeenCalledWith(
       mockChalk.bold.green(mocktFn("config.set.success")),
     );
@@ -122,13 +158,24 @@ describe("setupConfigSetCommand", () => {
   });
 
   it("should update global config settings when --global flag is used", async () => {
-    setupConfigSetCommand({ program: mockProgram, config, source: "local" });
+    mockReadAndMergeConfigs.mockResolvedValue({
+      config: JSON.parse(JSON.stringify(initialConfig)),
+      source: "global",
+    });
+    setupConfigSetCommand({
+      program: mockProgram,
+      config: initialConfig,
+      source: "local",
+    });
     const settings = ["packageManager", "pnpm"];
 
     await actionFn(settings, { global: true });
 
-    expect(config.settings.defaultPackageManager).toBe("pnpm");
-    expect(mockSaveGlobalConfig).toHaveBeenCalledWith(config);
+    const expectedConfig = {
+      ...initialConfig,
+      settings: { ...initialConfig.settings, defaultPackageManager: "pnpm" },
+    };
+    expect(mockSaveGlobalConfig).toHaveBeenCalledWith(expectedConfig);
     expect(mockSaveLocalConfig).not.toHaveBeenCalled();
     expect(mockSpinner.succeed).toHaveBeenCalledWith(
       mockChalk.bold.green(mocktFn("config.set.success")),
@@ -137,7 +184,15 @@ describe("setupConfigSetCommand", () => {
   });
 
   it("should throw an error if no config file is found", async () => {
-    setupConfigSetCommand({ program: mockProgram, config, source: "default" });
+    mockReadAndMergeConfigs.mockResolvedValue({
+      config: initialConfig,
+      source: "default",
+    });
+    setupConfigSetCommand({
+      program: mockProgram,
+      config: initialConfig,
+      source: "local",
+    });
     const settings = ["pm", "npm"];
 
     await actionFn(settings, { global: false });
@@ -149,7 +204,11 @@ describe("setupConfigSetCommand", () => {
   });
 
   it("should throw an error for an invalid number of arguments", async () => {
-    setupConfigSetCommand({ program: mockProgram, config, source: "local" });
+    setupConfigSetCommand({
+      program: mockProgram,
+      config: initialConfig,
+      source: "local",
+    });
     const settings = ["defaultPackageManager"];
 
     await actionFn(settings, { global: false });
@@ -161,7 +220,11 @@ describe("setupConfigSetCommand", () => {
   });
 
   it("should throw an error for an invalid key", async () => {
-    setupConfigSetCommand({ program: mockProgram, config, source: "local" });
+    setupConfigSetCommand({
+      program: mockProgram,
+      config: initialConfig,
+      source: "local",
+    });
     const settings = ["invalidKey", "someValue"];
 
     await actionFn(settings, { global: false });
@@ -178,7 +241,11 @@ describe("setupConfigSetCommand", () => {
   });
 
   it("should throw an error for an invalid value for package manager", async () => {
-    setupConfigSetCommand({ program: mockProgram, config, source: "local" });
+    setupConfigSetCommand({
+      program: mockProgram,
+      config: initialConfig,
+      source: "local",
+    });
     const settings = ["packageManager", "invalid-pm"];
 
     await actionFn(settings, { global: false });
@@ -195,7 +262,11 @@ describe("setupConfigSetCommand", () => {
   });
 
   it("should throw an error for an invalid value for cache strategy", async () => {
-    setupConfigSetCommand({ program: mockProgram, config, source: "local" });
+    setupConfigSetCommand({
+      program: mockProgram,
+      config: initialConfig,
+      source: "local",
+    });
     const settings = ["cacheStrategy", "invalid-cache"];
 
     await actionFn(settings, { global: false });
@@ -212,7 +283,11 @@ describe("setupConfigSetCommand", () => {
   });
 
   it("should throw an error for an invalid value for language", async () => {
-    setupConfigSetCommand({ program: mockProgram, config, source: "local" });
+    setupConfigSetCommand({
+      program: mockProgram,
+      config: initialConfig,
+      source: "local",
+    });
     const settings = ["language", "invalid-lang"];
 
     await actionFn(settings, { global: false });
@@ -232,7 +307,11 @@ describe("setupConfigSetCommand", () => {
     const mockError = new Error("Save failed");
     mockSaveLocalConfig.mockRejectedValue(mockError);
 
-    setupConfigSetCommand({ program: mockProgram, config, source: "local" });
+    setupConfigSetCommand({
+      program: mockProgram,
+      config: initialConfig,
+      source: "local",
+    });
     const settings = ["packageManager", "yarn"];
 
     await actionFn(settings, { global: false });

--- a/packages/devkit/__tests__/units/commands/config/validate-config.spec.ts
+++ b/packages/devkit/__tests__/units/commands/config/validate-config.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  validateConfigValue,
+  configAliases,
+} from "../../../../src/commands/config/validate-config.js";
+import {
+  PackageManagers,
+  VALID_CACHE_STRATEGIES,
+  TextLanguages,
+} from "#utils/configs/schema.js";
+import { DevkitError } from "#utils/errors/base.js";
+
+describe("validate-config.ts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("validateConfigValue", () => {
+    it("should not throw an error for a valid package manager", () => {
+      expect(() =>
+        validateConfigValue("defaultPackageManager", PackageManagers.Npm),
+      ).not.toThrow();
+    });
+
+    it("should throw an error for an invalid package manager", () => {
+      expect(() =>
+        validateConfigValue("defaultPackageManager", "invalid-pm"),
+      ).toThrow(DevkitError);
+      expect(() =>
+        validateConfigValue("defaultPackageManager", "invalid-pm"),
+      ).toThrow(
+        `error.invalid.value- options key:defaultPackageManager, options:${Object.values(PackageManagers).join(", ")}`,
+      );
+    });
+
+    it("should not throw an error for a valid cache strategy", () => {
+      expect(() =>
+        validateConfigValue("cacheStrategy", "always-refresh"),
+      ).not.toThrow();
+    });
+
+    it("should throw an error for an invalid cache strategy", () => {
+      expect(() =>
+        validateConfigValue("cacheStrategy", "invalid-cache"),
+      ).toThrow(DevkitError);
+      expect(() =>
+        validateConfigValue("cacheStrategy", "invalid-cache"),
+      ).toThrow(
+        `error.invalid.value- options key:cacheStrategy, options:${VALID_CACHE_STRATEGIES.join(", ")}`,
+      );
+    });
+
+    it("should not throw an error for a valid language", () => {
+      expect(() =>
+        validateConfigValue("language", TextLanguages.English),
+      ).not.toThrow();
+    });
+
+    it("should throw an error for an invalid language", () => {
+      expect(() => validateConfigValue("language", "français")).toThrow(
+        DevkitError,
+      );
+      expect(() => validateConfigValue("language", "français")).toThrow(
+        `error.invalid.value- options key:language, options:${Object.values(TextLanguages).join(", ")}`,
+      );
+    });
+
+    it("should not throw an error for an unknown key", () => {
+      expect(() =>
+        validateConfigValue("unknownKey", "some-value"),
+      ).not.toThrow();
+    });
+  });
+
+  describe("configAliases", () => {
+    it("should have correct mappings for package manager aliases", () => {
+      expect(configAliases.pm).toBe("defaultPackageManager");
+      expect(configAliases.packageManager).toBe("defaultPackageManager");
+    });
+
+    it("should have correct mappings for cache strategy aliases", () => {
+      expect(configAliases.cache).toBe("cacheStrategy");
+      expect(configAliases.cacheStrategy).toBe("cacheStrategy");
+    });
+
+    it("should have correct mappings for language aliases", () => {
+      expect(configAliases.language).toBe("language");
+      expect(configAliases.lg).toBe("language");
+    });
+  });
+});

--- a/packages/devkit/__tests__/units/utils/configs/loader.spec.ts
+++ b/packages/devkit/__tests__/units/utils/configs/loader.spec.ts
@@ -2,6 +2,7 @@ import { vi, describe, it, expect, beforeEach } from "vitest";
 import {
   getLocaleFromConfigMinimal,
   loadUserConfig,
+  readAndMergeConfigs,
 } from "../../../../src/utils/configs/loader.js";
 import {
   CONFIG_FILE_NAMES,
@@ -9,24 +10,47 @@ import {
 } from "../../../../src/utils/configs/schema.js";
 import { ConfigError } from "../../../../src/utils/errors/base.js";
 
-const { mockFindUp, mockReadConfigAtPath, mockGetConfigFilepath } = vi.hoisted(
-  () => ({
-    mockFindUp: vi.fn(),
-    mockReadConfigAtPath: vi.fn(),
-    mockGetConfigFilepath: vi.fn(),
-  }),
-);
+const {
+  mockFindUp,
+  mockReadConfigAtPath,
+  mockGetConfigFilepath,
+  mockFs,
+  mockFindGlobalConfigFile,
+  mockFindLocalConfigFile,
+} = vi.hoisted(() => ({
+  mockFindUp: vi.fn(),
+  mockReadConfigAtPath: vi.fn(),
+  mockGetConfigFilepath: vi.fn(),
+  mockFs: {
+    pathExists: vi.fn(),
+    readJson: vi.fn(),
+  },
+  mockFindGlobalConfigFile: vi.fn(),
+  mockFindLocalConfigFile: vi.fn(),
+}));
 
-vi.mock("../../../../src/utils/configs/path-finder.js", () => ({
+vi.mock("#utils/configs/path-finder.js", () => ({
   getConfigFilepath: mockGetConfigFilepath,
 }));
 
-vi.mock("../../../../src/utils/files/find-up.js", () => ({
+vi.mock("#utils/files/find-up.js", () => ({
   findUp: mockFindUp,
 }));
 
-vi.mock("../../../../src/utils/configs/reader.js", () => ({
+vi.mock("#utils/configs/reader.js", () => ({
   readConfigAtPath: mockReadConfigAtPath,
+}));
+
+vi.mock("fs-extra", () => ({
+  default: {
+    pathExists: mockFs.pathExists,
+    readJson: mockFs.readJson,
+  },
+}));
+
+vi.mock("#utils/files/finder.js", () => ({
+  findGlobalConfigFile: mockFindGlobalConfigFile,
+  findLocalConfigFile: mockFindLocalConfigFile,
 }));
 
 const mockOra = {
@@ -36,6 +60,9 @@ const mockOra = {
 describe("Configuration Loader Functions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetConfigFilepath.mockResolvedValue("/some/path/config.json");
+    mockFindGlobalConfigFile.mockResolvedValue("/global/config.json");
+    mockFindLocalConfigFile.mockResolvedValue("/local/config.json");
   });
 
   describe("getLocaleFromConfigMinimal", () => {
@@ -46,10 +73,8 @@ describe("Configuration Loader Functions", () => {
       });
       const locale = await getLocaleFromConfigMinimal();
       expect(locale).toBe("en");
-
       expect(mockReadConfigAtPath).toHaveBeenCalledOnce();
       expect(mockReadConfigAtPath).toHaveBeenCalledWith("/local/config.json");
-
       expect(mockFindUp).toHaveBeenCalledOnce();
       expect(mockFindUp).toHaveBeenCalledWith(
         [...CONFIG_FILE_NAMES],
@@ -59,16 +84,21 @@ describe("Configuration Loader Functions", () => {
 
     it("should return locale from global config if local is not found", async () => {
       mockFindUp.mockResolvedValueOnce(null);
+      mockGetConfigFilepath.mockResolvedValueOnce("/global/config.json");
       mockReadConfigAtPath.mockResolvedValueOnce({
         settings: { language: "fr" },
       });
       const locale = await getLocaleFromConfigMinimal();
       expect(locale).toBe("fr");
+      expect(mockReadConfigAtPath).toHaveBeenCalledWith("/global/config.json");
+      expect(mockFindUp).toHaveBeenCalledOnce();
+      expect(mockGetConfigFilepath).toHaveBeenCalledWith(true);
     });
 
     it("should return default locale if no config is found", async () => {
       mockFindUp.mockResolvedValueOnce(null);
-      mockReadConfigAtPath.mockResolvedValue(null);
+      mockGetConfigFilepath.mockResolvedValueOnce(null);
+      mockReadConfigAtPath.mockResolvedValueOnce(null);
       const locale = await getLocaleFromConfigMinimal();
       expect(locale).toBe(defaultCliConfig.settings.language);
     });
@@ -81,6 +111,33 @@ describe("Configuration Loader Functions", () => {
   });
 
   describe("loadUserConfig", () => {
+    it("should merge with global config if found", async () => {
+      mockGetConfigFilepath
+        .mockResolvedValueOnce("/global/config.json")
+        .mockResolvedValueOnce(null);
+      mockReadConfigAtPath.mockResolvedValueOnce({
+        settings: { language: "es" },
+      });
+      const { config, source } = await loadUserConfig(mockOra as any);
+      expect(config.settings.language).toBe("es");
+      expect(source).toBe("global");
+      expect(mockOra.text).toBe("config.check.local");
+    });
+
+    it("should merge with local config and override global", async () => {
+      mockGetConfigFilepath.mockResolvedValueOnce("/global/config.json");
+      mockReadConfigAtPath.mockResolvedValueOnce({
+        settings: { language: "es" },
+      });
+      mockGetConfigFilepath.mockResolvedValueOnce("/local/config.json");
+      mockReadConfigAtPath.mockResolvedValueOnce({
+        settings: { language: "fr" },
+      });
+      const { config, source } = await loadUserConfig(mockOra as any);
+      expect(config.settings.language).toBe("fr");
+      expect(source).toBe("local");
+    });
+
     it("should return default config if no files are found", async () => {
       mockGetConfigFilepath.mockResolvedValue(null);
       mockReadConfigAtPath.mockResolvedValue(null);
@@ -89,31 +146,62 @@ describe("Configuration Loader Functions", () => {
       expect(source).toBe("default");
       expect(mockOra.text).toBe("config.check.local");
     });
+  });
 
-    it("should merge with global config if found", async () => {
-      mockGetConfigFilepath.mockResolvedValueOnce("/global.json");
-      mockGetConfigFilepath.mockResolvedValueOnce(null);
-      mockReadConfigAtPath.mockResolvedValueOnce({
-        settings: { language: "es" },
-      });
-      mockReadConfigAtPath.mockResolvedValueOnce(null);
-      const { config, source } = await loadUserConfig(mockOra as any);
+  describe("readAndMergeConfigs", () => {
+    it("should merge with local config by default", async () => {
+      mockFindLocalConfigFile.mockResolvedValueOnce("/local/config.json");
+      mockFs.pathExists.mockResolvedValueOnce(true);
+      mockFs.readJson.mockResolvedValueOnce({ settings: { language: "fr" } });
+      const { config, source } = await readAndMergeConfigs();
+      expect(config.settings.language).toBe("fr");
+      expect(source).toBe("local");
+    });
+
+    it("should fallback to global if no local config exists", async () => {
+      mockFindLocalConfigFile.mockResolvedValueOnce(null);
+      mockFindGlobalConfigFile.mockResolvedValueOnce("/global/config.json");
+      mockFs.pathExists.mockResolvedValue(true);
+      mockFs.readJson.mockResolvedValueOnce({ settings: { language: "es" } });
+      const { config, source } = await readAndMergeConfigs();
       expect(config.settings.language).toBe("es");
       expect(source).toBe("global");
     });
 
-    it("should merge with local config and override global", async () => {
-      mockGetConfigFilepath.mockResolvedValueOnce("/global.json");
-      mockGetConfigFilepath.mockResolvedValueOnce("/local.json");
-      mockReadConfigAtPath.mockResolvedValueOnce({
-        settings: { language: "es" },
+    it("should use forced global config when options.forceGlobal is true", async () => {
+      mockFindGlobalConfigFile.mockResolvedValueOnce("/global/config.json");
+      mockFs.pathExists.mockResolvedValueOnce(true);
+      mockFs.readJson.mockResolvedValueOnce({ settings: { language: "pt" } });
+      const { config, source } = await readAndMergeConfigs({
+        forceGlobal: true,
       });
-      mockReadConfigAtPath.mockResolvedValueOnce({
-        settings: { language: "fr" },
-      });
-      const { config, source } = await loadUserConfig(mockOra as any);
-      expect(config.settings.language).toBe("fr");
-      expect(source).toBe("local");
+      expect(config.settings.language).toBe("pt");
+      expect(source).toBe("global");
+      expect(mockFindGlobalConfigFile).toHaveBeenCalled();
+      expect(mockFindLocalConfigFile).not.toHaveBeenCalled();
+    });
+
+    it("should return default config if no files are found", async () => {
+      mockFindLocalConfigFile.mockResolvedValueOnce(null);
+      mockFindGlobalConfigFile.mockResolvedValueOnce(null);
+      mockFs.pathExists.mockResolvedValue(false);
+      const { config, source } = await readAndMergeConfigs();
+      expect(config).toEqual(defaultCliConfig);
+      expect(source).toBe("default");
+    });
+
+    it("should return default config on invalid local file", async () => {
+      mockFindLocalConfigFile.mockResolvedValueOnce("/local/config.json");
+      mockFs.pathExists.mockResolvedValueOnce(true);
+      mockFs.readJson.mockRejectedValueOnce(new Error("Malformed JSON"));
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const { config, source } = await readAndMergeConfigs();
+      expect(config).toEqual(defaultCliConfig);
+      expect(source).toBe("default");
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/packages/devkit/locales/en.json
+++ b/packages/devkit/locales/en.json
@@ -114,6 +114,29 @@
       "updating": "Updating configuration...",
       "success": "Configuration updated successfully!"
     },
+    "get": {
+      "command": {
+        "description": "Get one or more configuration values."
+      },
+      "argument": {
+        "description": "The key of the configuration value to get (e.g., 'pm', 'language')."
+      },
+      "option": {
+        "global": "Get the global configuration instead of the local one."
+      },
+      "loading": "Loading configuration...",
+      "success": "Configuration loaded successfully!",
+      "not_found": "Configuration key '{key}' not found.",
+      "fallback": {
+        "global": "No global configuration file found. Displaying default settings instead.",
+        "local": "No local configuration file found. Displaying default settings instead.",
+        "local_to_global": "No local configuration file found. Displaying global settings instead."
+      },
+      "source": {
+        "local": "Using local configuration.",
+        "global": "Using global configuration."
+      }
+    },
     "init": {
       "command": {
         "description": "Initializes a configuration file with default settings."

--- a/packages/devkit/locales/fr.json
+++ b/packages/devkit/locales/fr.json
@@ -1,6 +1,6 @@
 {
   "program": {
-    "description": "Une boîte à outils de développement puissante pour l'échafaudage de nouveaux projets.",
+    "description": "Une CLI puissante pour automatiser la création de nouveaux projets.",
     "initialized": "CLI initialisée avec succès."
   },
   "new": {
@@ -19,9 +19,9 @@
           "description": "Le nom du modèle à utiliser (par exemple, 'ts', 'simple-api')"
         }
       },
-      "scaffolding": "Échafaudage du projet '{projectName}' avec le modèle '{template}'...",
+      "scaffolding": "Création du projet '{projectName}' avec le modèle '{template}'...",
       "success": "✅ Projet '{projectName}' créé avec succès !",
-      "fail": "❌ Échec de l'échafaudage du projet : {error}"
+      "fail": "❌ Échec de la création du projet : {error}"
     }
   },
   "list": {
@@ -62,7 +62,7 @@
       "argument": "Le nom ou l'alias du modèle à supprimer."
     },
     "option": {
-      "global": "Supprimer le modèle de la configuration globale au lieu de la configuration locale."
+      "global": "Supprimer le modèle de la configuration globale au lieu de la locale."
     }
   },
   "version": {
@@ -73,9 +73,9 @@
   },
   "scaffolding": {
     "project": {
-      "start": "Échafaudage du projet {language} : {project}",
+      "start": "Création du projet {language} : {project}",
       "success": "✅ Projet {language} '{project}' créé avec succès !",
-      "fail": "❌ Échec de l'échafaudage du projet {language} : {error}"
+      "fail": "❌ Échec de la création du projet {language} : {error}"
     },
     "copy": {
       "start": "📂 Copie des fichiers du modèle local...",
@@ -103,16 +103,39 @@
     },
     "set": {
       "command": {
-        "description": "Définir une ou plusieurs valeurs de configuration. \n\nClés disponibles :\n  pm, packageManager      - Définit le gestionnaire de paquets par défaut à utiliser pour les nouveaux projets.\n                          Valeurs possibles : {pmValues}\n  cache, cacheStrategy    - Définit le comportement global de la mise en cache pour les modèles distants.\n                          Valeurs possibles : 'always-refresh', 'never-refresh', 'daily'\n  language, lg            - Définit la langue de la CLI. Valeurs possibles : 'en', 'fr'\n"
+        "description": "Définir une ou plusieurs valeurs de configuration. \n\nClés disponibles :\n  pm, packageManager      - Définit le gestionnaire de paquets par défaut pour les nouveaux projets.\n                          Valeurs possibles : {pmValues}\n  cache, cacheStrategy    - Définit le comportement global de mise en cache pour les modèles distants.\n                          Valeurs possibles : 'always-refresh', 'never-refresh', 'daily'\n  language, lg            - Définit la langue de la CLI. Valeurs possibles : 'en', 'fr'\n"
       },
       "argument": {
         "description": "Une liste de paires clé-valeur à définir (par exemple, 'pm npm language fr')"
       },
       "option": {
-        "global": "Mettre à jour la configuration globale au lieu de la configuration locale."
+        "global": "Mettre à jour la configuration globale au lieu de la locale."
       },
       "updating": "Mise à jour de la configuration...",
       "success": "Configuration mise à jour avec succès !"
+    },
+    "get": {
+      "command": {
+        "description": "Obtenir une ou plusieurs valeurs de configuration."
+      },
+      "argument": {
+        "description": "La clé de la valeur de configuration à obtenir (par exemple, 'pm', 'language')."
+      },
+      "option": {
+        "global": "Obtenir la configuration globale au lieu de la locale."
+      },
+      "loading": "Chargement de la configuration...",
+      "success": "Configuration chargée avec succès !",
+      "not_found": "Clé de configuration '{key}' introuvable.",
+      "fallback": {
+        "global": "Aucun fichier de configuration globale trouvé. Affichage des paramètres par défaut à la place.",
+        "local": "Aucun fichier de configuration locale trouvé. Affichage des paramètres par défaut à la place.",
+        "local_to_global": "Aucun fichier de configuration locale trouvé. Affichage des paramètres globaux à la place."
+      },
+      "source": {
+        "local": "Utilisation de la configuration locale.",
+        "global": "Utilisation de la configuration globale."
+      }
     },
     "init": {
       "command": {
@@ -123,16 +146,16 @@
       "fail": "Échec de l'initialisation de la configuration.",
       "initializing": "Initialisation de la configuration...",
       "option": {
-        "local": "Initialiser un fichier de configuration local au lieu d'un global.",
-        "global": "Initialiser un fichier de configuration global au lieu d'un local."
+        "local": "Initialiser un fichier de configuration locale au lieu d'un global.",
+        "global": "Initialiser un fichier de configuration globale au lieu d'un local."
       },
       "confirm_overwrite": "Le fichier de configuration existe déjà à {path}. Voulez-vous l'écraser ?",
-      "confirm_monorepo_overwrite": "Un fichier de configuration existe déjà à la racine du monorepo à {path}. Voulez-vous en créer un nouveau dans le paquet actuel ?",
+      "confirm_monorepo_overwrite": "Un fichier de configuration existe à la racine du monorepo à {path}. Voulez-vous en créer un nouveau dans le package actuel ?",
       "found_existing": "Le fichier de configuration existe déjà à {path}. Initialisation ignorée.",
       "monorepo_location": "Une racine de monorepo a été trouvée, mais aucun fichier de configuration n'y existe. Où voulez-vous créer le nouveau fichier de configuration ?",
-      "location_current": "Le créer dans le paquet actuel.",
+      "location_current": "Le créer dans le package actuel.",
       "location_root": "Le créer à la racine du monorepo.",
-      "aborted": "Opération annulée. Aucune modification n'a été apportée."
+      "aborted": "Opération annulée. Aucune modification n'a été effectuée."
     },
     "update": {
       "command": {
@@ -146,12 +169,12 @@
       },
       "option": {
         "new_name": "Un nouveau nom pour le modèle.",
-        "description": "Une nouvelle brève description pour le modèle.",
+        "description": "Une nouvelle description pour le modèle.",
         "alias": "Un nouvel alias pour le modèle.",
         "location": "Un nouvel emplacement pour le modèle.",
-        "cache_strategy": "Une nouvelle stratégie de mise en cache pour le modèle.",
+        "cache_strategy": "Une nouvelle stratégie de cache pour le modèle.",
         "package_manager": "Un nouveau gestionnaire de paquets pour le modèle.",
-        "global": "Mettre à jour le modèle dans la configuration globale au lieu de la configuration locale."
+        "global": "Mettre à jour le modèle dans la configuration globale au lieu de la locale."
       },
       "updating": "Mise à jour du modèle '{templateName}' dans la configuration...",
       "success": "✅ Modèle '{templateName}' mis à jour avec succès !",
@@ -159,7 +182,7 @@
     },
     "cache": {
       "command": {
-        "description": "Mettre à jour la stratégie de mise en cache pour un modèle spécifique.",
+        "description": "Mettre à jour la stratégie de cache pour un modèle spécifique.",
         "start": "Mise à jour de la stratégie de cache pour le modèle '{template}'...",
         "fail": "❌ Échec de la mise à jour de la stratégie de cache pour le modèle '{template}'.",
         "success": "✨ Stratégie de cache pour le modèle '{template}' mise à jour en '{strategy}'."
@@ -177,7 +200,7 @@
     },
     "check": {
       "local": "Vérification de la configuration locale ou du monorepo...",
-      "global": "Configuration locale non trouvée. Vérification de la configuration globale..."
+      "global": "Configuration locale introuvable. Vérification de la configuration globale..."
     },
     "found": {
       "local": "Configuration locale trouvée et utilisée à {path}.",
@@ -203,11 +226,11 @@
       "save": "❌ Échec de l'enregistrement du fichier de configuration : {file}",
       "exists": "Le fichier existe déjà à {path}. Utilisez 'config set' pour le mettre à jour.",
       "not": {
-        "found": "Fichier de configuration non trouvé."
+        "found": "Fichier de configuration introuvable."
       },
       "global": {
         "not": {
-          "found": "Fichier de configuration globale non trouvé. Exécutez 'devkit config init --global' pour en créer un."
+          "found": "Fichier de configuration globale introuvable. Exécutez 'devkit config init --global' pour en créer un."
         }
       },
       "local": {
@@ -231,26 +254,26 @@
       "root": {
         "not_found": "Impossible de trouver la racine du projet contenant package.json."
       },
-      "file_not_found": "{file} non trouvé à {path}",
+      "file_not_found": "{file} introuvable à {path}",
       "failed_to_update_project_name": "Échec de la mise à jour du nom du projet :"
     },
     "version": {
       "read_fail": "Échec de la lecture de la version de package.json."
     },
     "template": {
-      "not_found": "Modèle '{template}' non trouvé dans la configuration.",
+      "not_found": "Modèle '{template}' introuvable dans la configuration.",
       "exists": "Le modèle '{template}' existe déjà dans la configuration. Utilisez 'devkit config set' pour le mettre à jour."
     },
     "alias": {
-      "exists": "L'alias '{alias}' existe déjà pour un autre modèle dans cette langue. Veuillez choisir un alias différent."
+      "exists": "L'alias '{alias}' existe déjà pour un autre modèle dans ce langage. Veuillez choisir un alias différent."
     },
     "install": {
       "message": "Erreur d'installation :"
     },
     "scaffolding": {
-      "unexpected": "Une erreur inattendue est survenue lors de l'échafaudage.",
+      "unexpected": "Une erreur inattendue est survenue lors de la création.",
       "language": {
-        "not_found": "Langage d'échafaudage non trouvé dans la configuration : '{language}'"
+        "not_found": "Langage de création introuvable dans la configuration : '{language}'"
       }
     },
     "command": {
@@ -269,7 +292,7 @@
     "save": {
       "local": {
         "config": {
-          "not_found": "Échec de l'enregistrement de la configuration locale. Fichier non trouvé à '{path}'."
+          "not_found": "Échec de l'enregistrement de la configuration locale. Fichier introuvable à '{path}'."
         }
       }
     },
@@ -278,7 +301,7 @@
     },
     "unexpected": "Une erreur inattendue est survenue",
     "unknown": "Une erreur inconnue est survenue",
-    "language_config_not_found": "Langage d'échafaudage non trouvé dans la configuration : '{language}'"
+    "language_config_not_found": "Langage de création introuvable dans la configuration : '{language}'"
   },
   "cache": {
     "clone": {
@@ -287,15 +310,15 @@
       "fail": "❌ Échec du clonage du dépôt."
     },
     "refresh": {
-      "start": "🔄 Rafraîchissement du modèle mis en cache...",
-      "success": "✅ Modèle rafraîchi avec succès !",
-      "fail": "❌ Échec du rafraîchissement du modèle."
+      "start": "🔄 Actualisation du modèle en cache...",
+      "success": "✅ Modèle actualisé avec succès !",
+      "fail": "❌ Échec de l'actualisation du modèle."
     },
     "use": {
-      "info": "🚀 Utilisation du modèle mis en cache pour {repoName}."
+      "info": "🚀 Utilisation du modèle en cache pour {repoName}."
     },
     "copy": {
-      "start": "📂 Copie du modèle mis en cache vers le répertoire du projet...",
+      "start": "📂 Copie du modèle en cache vers le répertoire du projet...",
       "success": "✅ Fichiers copiés avec succès !",
       "fail": "❌ Échec de la copie des fichiers depuis le cache."
     }

--- a/packages/devkit/src/commands/config/get.ts
+++ b/packages/devkit/src/commands/config/get.ts
@@ -1,0 +1,77 @@
+import {
+  type CliConfig,
+  type SetupCommandOptions,
+} from "#utils/configs/schema.js";
+import { t } from "#utils/internationalization/i18n.js";
+import { handleErrorAndExit } from "#utils/errors/handler.js";
+import { configAliases } from "./validate-config.js";
+import chalk from "chalk";
+import ora from "ora";
+import { readAndMergeConfigs } from "#utils/configs/loader.js";
+
+export function setupConfigGetCommand(options: SetupCommandOptions): void {
+  const { program } = options;
+
+  program
+    .command("get")
+    .description(t("config.get.command.description"))
+    .argument("[key]", t("config.get.argument.description"), "")
+    .option("-g, --global", t("config.get.option.global"), false)
+    .action(async (key, cmdOptions) => {
+      const spinner = ora(chalk.cyan(t("config.get.loading"))).start();
+
+      let activeConfig: CliConfig["settings"];
+      let sourceMessage: string | null = null;
+      let configSource: string;
+
+      try {
+        const { config, source } = await readAndMergeConfigs({
+          forceGlobal: cmdOptions.global,
+          forceLocal: !cmdOptions.global,
+        });
+
+        activeConfig = config.settings;
+        configSource = source;
+
+        if (cmdOptions.global) {
+          if (configSource === "default") {
+            sourceMessage = t("config.get.fallback.global");
+          } else {
+            sourceMessage = t("config.get.source.global");
+          }
+        } else {
+          if (configSource === "default") {
+            sourceMessage = t("config.get.fallback.local");
+          } else if (configSource === "global") {
+            sourceMessage = t("config.get.fallback.local_to_global");
+          } else {
+            sourceMessage = t("config.get.source.local");
+          }
+        }
+
+        spinner.succeed(chalk.bold.green(t("config.get.success")));
+
+        if (sourceMessage) {
+          console.log(chalk.bold.yellow(sourceMessage));
+        }
+
+        if (key) {
+          const canonicalKey = configAliases[key] || key;
+          const value =
+            activeConfig[canonicalKey as keyof CliConfig["settings"]];
+          if (value !== undefined) {
+            console.log(chalk.cyan(`${canonicalKey}:`), chalk.white(value));
+          } else {
+            console.log(
+              chalk.red(t("config.get.not_found", { key: canonicalKey })),
+            );
+          }
+        } else {
+          const formattedConfig = JSON.stringify(activeConfig, null, 2);
+          console.log(chalk.white(formattedConfig));
+        }
+      } catch (error) {
+        handleErrorAndExit(error, spinner);
+      }
+    });
+}

--- a/packages/devkit/src/commands/config/index.ts
+++ b/packages/devkit/src/commands/config/index.ts
@@ -1,6 +1,7 @@
 import { type SetupCommandOptions } from "#utils/configs/schema.js";
 import { t } from "#utils/internationalization/i18n.js";
 import { setupConfigSetCommand } from "#commands/config/set.js";
+import { setupConfigGetCommand } from "#commands/config/get.js";
 
 export function setupConfigCommand(options: SetupCommandOptions) {
   const { program, config, source } = options;
@@ -10,4 +11,5 @@ export function setupConfigCommand(options: SetupCommandOptions) {
     .description(t("config.command.description"));
 
   setupConfigSetCommand({ program: configCommand, config, source });
+  setupConfigGetCommand({ program: configCommand, config, source });
 }

--- a/packages/devkit/src/commands/config/validate-config.ts
+++ b/packages/devkit/src/commands/config/validate-config.ts
@@ -1,0 +1,54 @@
+import {
+  PackageManagers,
+  type PackageManager,
+  type CacheStrategy,
+  VALID_CACHE_STRATEGIES,
+  TextLanguages,
+  type TextLanguageValues,
+  type CliConfig,
+} from "#utils/configs/schema.js";
+import { t } from "#utils/internationalization/i18n.js";
+import { DevkitError } from "#utils/errors/base.js";
+
+export function validateConfigValue(key: string, value: unknown): void {
+  if (key === "defaultPackageManager") {
+    const validPackageManagers = Object.values(PackageManagers);
+    if (!validPackageManagers.includes(value as PackageManager)) {
+      throw new DevkitError(
+        t("error.invalid.value", {
+          key,
+          options: validPackageManagers.join(", "),
+        }),
+      );
+    }
+  } else if (key === "cacheStrategy") {
+    const validStrategies = VALID_CACHE_STRATEGIES;
+    if (!validStrategies.includes(value as CacheStrategy)) {
+      throw new DevkitError(
+        t("error.invalid.value", {
+          key,
+          options: validStrategies.join(", "),
+        }),
+      );
+    }
+  } else if (key === "language") {
+    const validLanguages = Object.values(TextLanguages);
+    if (!validLanguages.includes(value as TextLanguageValues)) {
+      throw new DevkitError(
+        t("error.invalid.value", {
+          key,
+          options: validLanguages.join(", "),
+        }),
+      );
+    }
+  }
+}
+
+export const configAliases: Record<string, keyof CliConfig["settings"]> = {
+  pm: "defaultPackageManager",
+  packageManager: "defaultPackageManager",
+  cache: "cacheStrategy",
+  cacheStrategy: "cacheStrategy",
+  language: "language",
+  lg: "language",
+};


### PR DESCRIPTION
## Description

This pull request introduces the new `config get` command, enabling users to retrieve configuration values directly from the CLI. This feature addresses the need for a simple way to inspect current settings without manually opening and reading the configuration files.

The command offers flexible usage:
* **`dk config get <key>`**: Retrieves the value for a specific setting key (e.g., `dk config get pm`).
* **`dk config get --global`**: Fetches the value from the global configuration file.
* **`dk config get` (without a key)**: Displays the entire configuration, showing all settings and templates currently in use.

This feature is fully integrated with the existing configuration hierarchy, ensuring that it respects local, global, and default fallbacks.

Fixes # (Issue number for the new feature)

---

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing feature support current supported languages
- [x] Any dependent changes have been merged and published in downstream modules